### PR TITLE
Only connect input vectors to referenced input ports, because connect…

### DIFF
--- a/src/main/scala/Chisel/hwiotesters/SteppedHWIOTester.scala
+++ b/src/main/scala/Chisel/hwiotesters/SteppedHWIOTester.scala
@@ -168,7 +168,7 @@ abstract class SteppedHWIOTester extends HWIOTester {
 
     when(!done) {
       io_info.dut_inputs.filter(io_info.ports_referenced.contains).foreach { port => createVectorsForInput(port, pc) }
-      io_info.dut_outputs.foreach { port => createVectorsAndTestsForOutput(port, pc) }
+      io_info.dut_outputs.filter(io_info.ports_referenced.contains).foreach { port => createVectorsAndTestsForOutput(port, pc) }
 
       when(pc.inc()) {
         printf(s"Stopping, end of tests, ${test_actions.length} steps\n")

--- a/src/main/scala/Chisel/hwiotesters/SteppedHWIOTester.scala
+++ b/src/main/scala/Chisel/hwiotesters/SteppedHWIOTester.scala
@@ -167,7 +167,7 @@ abstract class SteppedHWIOTester extends HWIOTester {
     val done           = Reg(init = Bool(false))
 
     when(!done) {
-      io_info.dut_inputs.foreach { port => createVectorsForInput(port, pc) }
+      io_info.dut_inputs.filter(io_info.ports_referenced.contains).foreach { port => createVectorsForInput(port, pc) }
       io_info.dut_outputs.foreach { port => createVectorsAndTestsForOutput(port, pc) }
 
       when(pc.inc()) {

--- a/src/test/scala/examples/MaxN.scala
+++ b/src/test/scala/examples/MaxN.scala
@@ -1,0 +1,43 @@
+// See LICENSE for license details.
+
+package examples
+
+import Chisel._
+import Chisel.hwiotesters.{ChiselFlatSpec, SteppedHWIOTester}
+
+class MaxN(val n: Int, val w: Int) extends Module {
+
+  private def Max2(x: UInt, y: UInt) = Mux(x > y, x, y)
+
+  val io = new Bundle {
+    val ins = Vec(n, UInt(INPUT, w))
+    val out = UInt(OUTPUT, w)
+  }
+  io.out := io.ins.reduceLeft(Max2)
+}
+
+class MaxNTests(val n: Int, val w: Int) extends SteppedHWIOTester {
+  val device_under_test = Module(new MaxN(n, w))
+  val c = device_under_test
+
+  val ins = Array.fill(c.n) {
+    0
+  }
+  for (i <- 0 until 10) {
+    var mx = 0
+    for (i <- 0 until c.n) {
+      ins(i) = rnd.nextInt(1 << c.w)
+      poke(c.io.ins(i), ins(i))
+      mx = if (ins(i) > mx) ins(i) else mx;
+    }
+    expect(c.io.out, mx)
+    step(1)
+  }
+}
+
+class MaxNSpec extends ChiselFlatSpec {
+  "MaxN using reduction to connect things" should "build and run" in {
+    assertTesterPasses{ new MaxNTests(10, 16) }
+  }
+}
+


### PR DESCRIPTION
wiring unreferenced aggregate inputs (which stepped tester did by default) caused run time connect errors.  This fixes the problem by not wiring unreferenced ports.  This means unreferenced ports do not have connections made by the tester.  This should be discussed, but this fix should be accepted for chisel-tutorial deployment