### PR TITLE
Replace 'to' with 'until' in for loops.

### DIFF
--- a/src/test/scala/examples/DynamicMemorySearch.scala
+++ b/src/test/scala/examples/DynamicMemorySearch.scala
@@ -20,7 +20,7 @@ class DynamicMemorySearch(val n: Int, val w: Int) extends Module {
   val over   = !io.en && ((memVal === io.data) || (index === UInt(n-1)))
 
   when(reset) {
-    for(i <- 0 to n) {
+    for(i <- 0 until n) {
       list(i) := UInt(0)
     }
   }

--- a/src/test/scala/examples/Router.scala
+++ b/src/test/scala/examples/Router.scala
@@ -141,7 +141,7 @@ class RouterUnitTester(number_of_packets_to_send: Int) extends OrderedDecoupledH
   }
 
   // send a bunch of packets, with random values
-  for (i <- 0 to number_of_packets_to_send) {
+  for (i <- 0 until number_of_packets_to_send) {
     val data = rnd.nextInt(Int.MaxValue - 1)
     routePacket(i % Router.routeTableSize, data, new_routing_table(i % Router.routeTableSize))
   }


### PR DESCRIPTION
The upper bound in the loop in src/test/scala/examples/Router.scala is benign since we use modulus, but the name is number_of_packets_to_send so while we're here ...