### PR TITLE
More features

### DIFF
--- a/src/main/scala/Chisel/iotesters/AdvTester.scala
+++ b/src/main/scala/Chisel/iotesters/AdvTester.scala
@@ -21,9 +21,10 @@ trait AdvTests extends PeekPokeTests {
 abstract class AdvTester[+T <: Module](
                                        dut: T,
                                        verbose: Boolean = false,
+                                       _base: Int = 16,
                                        logFile: Option[String] = chiselMain.context.logFile,
-                                       _base: Int = 16)
-                extends PeekPokeTester(dut, verbose, logFile, _base) {
+                                       waveform: Option[String] = chiselMain.context.waveform)
+                extends PeekPokeTester(dut, verbose, _base, logFile, waveform) {
   val defaultMaxCycles = 1024L
   var _cycles = 0L
   def cycles = _cycles

--- a/src/main/scala/Chisel/iotesters/AdvTester.scala
+++ b/src/main/scala/Chisel/iotesters/AdvTester.scala
@@ -18,8 +18,12 @@ trait AdvTests extends PeekPokeTests {
   def do_until(work: =>Unit)(pred: =>Boolean, maxCycles: Long = 0L): Boolean
 }
 
-abstract class AdvTester[+T <: Module](dut: T, verbose: Boolean = false)
-    extends PeekPokeTester(dut, verbose) {
+abstract class AdvTester[+T <: Module](
+                                       dut: T,
+                                       verbose: Boolean = false,
+                                       logFile: Option[String] = chiselMain.context.logFile,
+                                       _base: Int = 16)
+                extends PeekPokeTester(dut, verbose, logFile, _base) {
   val defaultMaxCycles = 1024L
   var _cycles = 0L
   def cycles = _cycles
@@ -62,9 +66,13 @@ abstract class AdvTester[+T <: Module](dut: T, verbose: Boolean = false)
       postprocessors.foreach(_.process())
     } catch {
       case e: java.lang.AssertionError =>
-        assert(false, e.toString) // catch assert
+        // catch assert
+        if (verbose) logger println e.toString
+        assert(false, e.toString)
       case e: java.lang.IllegalArgumentException =>
-        assert(false, e.toString) // catch require
+        // catch require
+        if (verbose) logger println e.toString
+        assert(false, e.toString)
     }
   }
   def takesteps(n: Int)(work: =>Unit = {}): Unit = {

--- a/src/main/scala/Chisel/iotesters/Backends.scala
+++ b/src/main/scala/Chisel/iotesters/Backends.scala
@@ -8,6 +8,8 @@ import Chisel._
   */
 
 abstract class Backend {
+  def rnd: scala.util.Random
+
   def poke(data: Bits, signal: BigInt): Unit
 
   def peek(data: Bits): BigInt

--- a/src/main/scala/Chisel/iotesters/ChiselMain.scala
+++ b/src/main/scala/Chisel/iotesters/ChiselMain.scala
@@ -20,6 +20,7 @@ private[iotesters] class TesterContext {
   val testCmd = ArrayBuffer[String]()
   var targetDir = new File("test_run_dir").getCanonicalPath
   var logFile: Option[String] = None
+  var waveform: Option[String] = None
 }
 
 object chiselMain {
@@ -44,6 +45,7 @@ object chiselMain {
         case "--targetDir" => context.targetDir = args(i+1)
         case "--noUpdate" => context.isUpdate = false
         case "--logFile" => context.logFile = Some(args(i+1))
+        case "--waveform" => context.waveform = Some(args(i+1))
         case _ =>
       }
     }

--- a/src/main/scala/Chisel/iotesters/ChiselMain.scala
+++ b/src/main/scala/Chisel/iotesters/ChiselMain.scala
@@ -29,20 +29,14 @@ object chiselMain {
       args(i) match {
         case "--vcs" => context.isVCS = true
         case "--v" => context.isGenVerilog = true
-        case "--backend" => {
-          if(args(i+1) == "v") {
-            context.isGenVerilog = true
-          } else if(args(i+1) == "c") {
-            context.isGenVerilog = true
-          }
+        case "--backend" => args(i+1) match {
+          case "v" => context.isGenVerilog = true
+          case "c" => context.isGenVerilog = true
+          case _ =>
         }
         case "--genHarness" => context.isGenHarness = true
-        case "--compile" => {
-          context.isCompiling = true
-        }
-        case "--test" => {
-          context.isRunTest = true
-        }
+        case "--compile" => context.isCompiling = true
+        case "--test" => context.isRunTest = true
         case "--testCommand" => context.testCmd ++= args(i+1) split ' '
         case "--targetDir" => context.targetDir = args(i+1)
         case _ =>
@@ -62,11 +56,11 @@ object chiselMain {
     firrtl.Driver.compile(firrtlIRFilePath, verilogFilePath, new firrtl.VerilogCompiler())
   }
 
-  private def genHarness[T <: Module](dutGen: () => Module, isVCS: Boolean, verilogFileName:String, cppHarnessFilePath:String, vcdFilePath: String) {
+  private def genHarness[T <: Module](dutGen: () => Module, isVCS: Boolean, verilogFileName:String, harnessFilePath:String, vcdFilePath: String) {
     if (isVCS) {
       assert(false, "unimplemented")
     } else {
-      genVerilatorCppHarness(dutGen, verilogFileName, cppHarnessFilePath, vcdFilePath)
+      genVerilatorCppHarness(dutGen, verilogFileName, harnessFilePath, vcdFilePath)
     }
   }
 
@@ -79,8 +73,7 @@ object chiselMain {
     if (context.isVCS) {
     } else {
       // Generate Verilator
-      val harness = new File(s"${dir}/${dutName}-harness.cpp")
-      Driver.verilogToCpp(dutName, dutName, dir, Seq(), harness).!
+      Driver.verilogToCpp(dutName, dutName, dir, Seq(), new File(s"${dutName}-harness.cpp")).!
       // Compile Verilator
       Driver.cppToExe(dutName, dir).!
     }

--- a/src/main/scala/Chisel/iotesters/ChiselMain.scala
+++ b/src/main/scala/Chisel/iotesters/ChiselMain.scala
@@ -15,6 +15,7 @@ private[iotesters] class TesterContext {
   var isGenHarness = false
   var isCompiling = false
   var isRunTest = false
+  var isUpdate = true
   var testerSeed = System.currentTimeMillis
   val testCmd = ArrayBuffer[String]()
   var targetDir = new File("test_run_dir").getCanonicalPath
@@ -39,6 +40,7 @@ object chiselMain {
         case "--test" => context.isRunTest = true
         case "--testCommand" => context.testCmd ++= args(i+1) split ' '
         case "--targetDir" => context.targetDir = args(i+1)
+        case "--noUpdate" => context.isUpdate = false
         case _ =>
       }
     }

--- a/src/main/scala/Chisel/iotesters/ChiselMain.scala
+++ b/src/main/scala/Chisel/iotesters/ChiselMain.scala
@@ -19,6 +19,7 @@ private[iotesters] class TesterContext {
   var testerSeed = System.currentTimeMillis
   val testCmd = ArrayBuffer[String]()
   var targetDir = new File("test_run_dir").getCanonicalPath
+  var logFile: Option[String] = None
 }
 
 object chiselMain {
@@ -41,6 +42,7 @@ object chiselMain {
         case "--testCommand" => context.testCmd ++= args(i+1) split ' '
         case "--targetDir" => context.targetDir = args(i+1)
         case "--noUpdate" => context.isUpdate = false
+        case "--logFile" => context.logFile = Some(args(i+1))
         case _ =>
       }
     }

--- a/src/main/scala/Chisel/iotesters/ChiselMain.scala
+++ b/src/main/scala/Chisel/iotesters/ChiselMain.scala
@@ -40,6 +40,7 @@ object chiselMain {
         case "--compile" => context.isCompiling = true
         case "--test" => context.isRunTest = true
         case "--testCommand" => context.testCmd ++= args(i+1) split ' '
+        case "--testerSeed" => context.testerSeed = args(i+1).toLong
         case "--targetDir" => context.targetDir = args(i+1)
         case "--noUpdate" => context.isUpdate = false
         case "--logFile" => context.logFile = Some(args(i+1))

--- a/src/main/scala/Chisel/iotesters/FirrtlTerpBackend.scala
+++ b/src/main/scala/Chisel/iotesters/FirrtlTerpBackend.scala
@@ -9,9 +9,14 @@ import scala.collection.mutable.HashMap
 
 import firrtl_interpreter.InterpretiveTester
 
-private[iotesters] class FirrtlTerpBackend(dut: Module, firrtlIR: String, verbose: Boolean = true) extends Backend {
+private[iotesters] class FirrtlTerpBackend(
+                                           dut: Module,
+                                           firrtlIR: String,
+                                           verbose: Boolean = true,
+                                           logger: PrintStream = System.out,
+                                           _base: Int = 16) extends Backend {
   val interpretiveTester = new InterpretiveTester(firrtlIR)
-  reset(5)//reset firrtl interpreter on construction
+  reset(5) // reset firrtl interpreter on construction
 
   private val ioNameMap = {
     val result = HashMap[Data, String]()
@@ -28,13 +33,13 @@ private[iotesters] class FirrtlTerpBackend(dut: Module, firrtlIR: String, verbos
   override def poke(signal: Bits, value: BigInt): Unit = {
     val name = getIPCName(signal)
     interpretiveTester.poke(name, value)
-    if (verbose) println(s"  POKE ${name} <- ${bigIntToStr(value, 16)}")
+    if (verbose) logger println s"  POKE ${name} <- ${bigIntToStr(value, _base)}"
   }
 
   override def peek(signal: Bits): BigInt = {
     val name = getIPCName(signal)
     val result = interpretiveTester.peek(name)
-    if (verbose) println(s"  PEEK ${name} -> ${bigIntToStr(result, 16)}")
+    if (verbose) logger println s"  PEEK ${name} -> ${bigIntToStr(result, _base)}"
     result
   }
 
@@ -42,7 +47,7 @@ private[iotesters] class FirrtlTerpBackend(dut: Module, firrtlIR: String, verbos
     val name = getIPCName(signal)
     val got = interpretiveTester.peek(name)
     val good = got == expected
-    if (verbose) println(s"""${msg}  EXPECT ${name} -> ${bigIntToStr(got, 16)} == ${bigIntToStr(expected, 16)} ${if (good) "PASS" else "FAIL"}""")
+    if (verbose) logger println s"""${msg}  EXPECT ${name} -> ${bigIntToStr(got, _base)} == ${bigIntToStr(expected, _base)} ${if (good) "PASS" else "FAIL"}"""
     good
   }
 

--- a/src/main/scala/Chisel/iotesters/PeekPokeTester.scala
+++ b/src/main/scala/Chisel/iotesters/PeekPokeTester.scala
@@ -27,8 +27,9 @@ trait PeekPokeTests {
 abstract class PeekPokeTester[+T <: Module](
                                             val dut: T,
                                             verbose: Boolean = true,
-                                            logFile: Option[String] = chiselMain.context.logFile,
                                             _base: Int = 16,
+                                            logFile: Option[String] = chiselMain.context.logFile,
+                                            waveform: Option[String] = chiselMain.context.waveform,
                                             _backend: Option[Backend] = None,
                                             _seed: Long = System.currentTimeMillis) {
 
@@ -47,8 +48,12 @@ abstract class PeekPokeTester[+T <: Module](
   /*** Simulation Interface ***/
   /****************************/
   logger println s"SEED ${_seed}"
+  val cmd = chiselMain.context.testCmd.toList ++ (waveform match {
+    case None    => Nil
+    case Some(f) => logger println s"Waveform: $f" ; List(s"+waveform=$f")
+  })
   val backend = _backend getOrElse(new VerilatorBackend(
-    dut, chiselMain.context.testCmd mkString " ", verbose, logger, _base, _seed))
+    dut, cmd, verbose, logger, _base, _seed))
 
   /********************************/
   /*** Classic Tester Interface ***/

--- a/src/main/scala/Chisel/iotesters/PeekPokeTester.scala
+++ b/src/main/scala/Chisel/iotesters/PeekPokeTester.scala
@@ -7,9 +7,7 @@ import Chisel._
 import scala.util.Random
 
 // Provides a template to define tester transactions
-private [iotesters] trait PeekPokeTests {
-  type DUT <: Module
-  def dut: DUT
+trait PeekPokeTests {
   def t: Long
   def rnd: Random
   implicit def int(x: Boolean): BigInt
@@ -56,7 +54,7 @@ abstract class PeekPokeTester[+T <: Module](
     ok = false
   }
 
-  val rnd = new Random(_seed)
+  val rnd = backend.rnd
 
   /** Convert a Boolean to BigInt */
   implicit def int(x: Boolean): BigInt = if (x) 1 else 0

--- a/src/main/scala/Chisel/iotesters/PeekPokeTesterDrivers.scala
+++ b/src/main/scala/Chisel/iotesters/PeekPokeTesterDrivers.scala
@@ -167,7 +167,6 @@ object genVerilatorCppHarness {
     fileWriter.write("        if (tfp) tfp->dump(main_time);\n")
     fileWriter.write("#endif\n")
     fileWriter.write("        dut->clk = 0;\n")
-    fileWriter.write("        dut->eval();\n")
     fileWriter.write("        main_time++;\n")
     fileWriter.write("    }\n")
     fileWriter.write("    virtual inline void update() {\n")

--- a/src/main/scala/Chisel/iotesters/PeekPokeTesterDrivers.scala
+++ b/src/main/scala/Chisel/iotesters/PeekPokeTesterDrivers.scala
@@ -176,12 +176,18 @@ object genVerilatorCppHarness {
     fileWriter.write("int main(int argc, char **argv, char **env) {\n")
     fileWriter.write("    Verilated::commandArgs(argc, argv);\n")
     fileWriter.write(s"    ${dutVerilatorClassName}* top = new ${dutVerilatorClassName};\n")
+    fileWriter.write("    std::string vcdfile = \"%s\";\n".format(vcdFilePath))
+    fileWriter.write("    std::vector<std::string> args(argv+1, argv+argc);\n")
+    fileWriter.write("    std::vector<std::string>::const_iterator it;\n")
+    fileWriter.write("    for (it = args.begin() ; it != args.end() ; it++) {\n")
+    fileWriter.write("      if (it->find(\"+waveform=\") == 0) vcdfile = it->c_str()+10;\n")
+    fileWriter.write("    }\n")
     fileWriter.write("#if VM_TRACE\n")
     fileWriter.write("    Verilated::traceEverOn(true);\n")
     fileWriter.write("    VL_PRINTF(\"Enabling waves..\");\n")
     fileWriter.write("    VerilatedVcdC* tfp = new VerilatedVcdC;\n")
     fileWriter.write("    top->trace(tfp, 99);\n")
-    fileWriter.write("    tfp->open(\"%s\");\n".format(vcdFilePath))
+    fileWriter.write("    tfp->open(vcdfile.c_str());\n")
     fileWriter.write("#endif\n")
     fileWriter.write(s"    ${dutApiClassName} api(top);\n")
     fileWriter.write("    api.init_sim_data();\n")
@@ -211,7 +217,7 @@ object runPeekPokeTesterWithVerilatorBinary {
                          (testerGen: (T, Option[Backend]) => PeekPokeTester[T]): Boolean = {
     lazy val dut = dutGen() //HACK to get Module instance for now; DO NOT copy
     Driver.elaborate(() => dut)
-    val tester = testerGen(dut, Some(new VerilatorBackend(dut, verilatorBinaryFilePath)))
+    val tester = testerGen(dut, Some(new VerilatorBackend(dut, List(verilatorBinaryFilePath))))
     tester.finish
   }
 }

--- a/src/main/scala/Chisel/iotesters/SimApiInterface.scala
+++ b/src/main/scala/Chisel/iotesters/SimApiInterface.scala
@@ -153,7 +153,7 @@ private[iotesters] class SimApiInterface(dut: Module, cmd: String) {
     mwhile(!sendCmd(SIM_CMD.STEP)) { }
     mwhile(!sendInputs) { }
     mwhile(!recvOutputs) { }
-    isStale = false
+    isStale = true
   }
 
   private def getId(path: String) = {
@@ -223,7 +223,7 @@ private[iotesters] class SimApiInterface(dut: Module, cmd: String) {
   }
 
   def peek(signal: String) = {
-    if (isStale) update
+    if (isStale && chiselMain.context.isUpdate) update
     if (outputsNameToChunkSizeMap contains signal) _peekMap get signal
     else if (inputsNameToChunkSizeMap contains signal) _pokeMap get signal
     else None

--- a/src/main/scala/Chisel/iotesters/SimApiInterface.scala
+++ b/src/main/scala/Chisel/iotesters/SimApiInterface.scala
@@ -255,6 +255,7 @@ private[iotesters] class SimApiInterface(
     inChannel.close
     outChannel.close
     cmdChannel.close
+    chiselMain.context.processes -= process
   }
 
   //initialize cpp process and memory mapped channels
@@ -300,6 +301,7 @@ private[iotesters] class SimApiInterface(
     in_channel.release
     out_channel.release
     cmd_channel.release
+    chiselMain.context.processes += process
 
     (process, exitValue, in_channel, out_channel, cmd_channel)
   }

--- a/src/main/scala/Chisel/iotesters/SimApiInterface.scala
+++ b/src/main/scala/Chisel/iotesters/SimApiInterface.scala
@@ -13,7 +13,7 @@ import java.nio.channels.FileChannel
 
 private[iotesters] class SimApiInterface(
                                          dut: Module,
-                                         cmd: String,
+                                         cmd: List[String],
                                          logger: java.io.PrintStream) {
   val (inputsNameToChunkSizeMap, outputsNameToChunkSizeMap) = {
     def genChunk(arg: (Bits, (String, String))) = arg match {case (io, (_, name)) =>
@@ -214,7 +214,7 @@ private[iotesters] class SimApiInterface(
   }
 
   private def start {
-    println(s"STARTING ${cmd}")
+    println(s"""STARTING ${cmd mkString " "}""")
     mwhile(!recvOutputs) { }
     // reset(5)
     for (i <- 0 until 5) {
@@ -259,8 +259,8 @@ private[iotesters] class SimApiInterface(
 
   //initialize cpp process and memory mapped channels
   private val (process: Process, exitValue: Future[Int], inChannel, outChannel, cmdChannel) = {
-    require(new java.io.File(cmd).exists, s"${cmd} doesn't exists")
-    val processBuilder = Process(cmd)
+    require(new java.io.File(cmd.head).exists, s"${cmd.head} doesn't exists")
+    val processBuilder = Process(cmd mkString " ")
     val processLogger = ProcessLogger(println, _logs += _) // don't log stdout
     val process = processBuilder run processLogger
 

--- a/src/main/scala/Chisel/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/Chisel/iotesters/VerilatorBackend.scala
@@ -24,12 +24,10 @@ private[iotesters] object setupVerilatorBackend {
     // Dump FIRRTL for debugging
     val firrtlIRFilePath = s"${testDirPath}/${circuit.name}.ir"
     Chisel.Driver.dumpFirrtl(circuit, Some(new File(firrtlIRFilePath)))
-    // Parse FIRRTL
-    //val ir = firrtl.Parser.parse(Chisel.Driver.emit(dutGen) split "\n")
     // Generate Verilog
     val verilogFilePath = s"${testDirPath}/${circuit.name}.v"
     //val v = new PrintWriter(new File(s"${dir}/${circuit.name}.v"))
-    firrtl.Driver.compile(firrtlIRFilePath, verilogFilePath, new firrtl.VerilogCompiler())
+    firrtl.Driver.compile(firrtlIRFilePath, verilogFilePath, new firrtl.VerilogCompiler)
 
     val verilogFileName = verilogFilePath.split("/").last
     val cppHarnessFileName = "classic_tester_top.cpp"
@@ -43,7 +41,7 @@ private[iotesters] object setupVerilatorBackend {
     Driver.elaborate(() => dut)
 
     genVerilatorCppHarness(dutGen, verilogFileName, cppHarnessFilePath, vcdFilePath)
-    Chisel.Driver.verilogToCpp(verilogFileName.split("\\.")(0), dut.name, new File(testDirPath), Seq(), new File(cppHarnessFilePath)).!
+    Chisel.Driver.verilogToCpp(verilogFileName.split("\\.")(0), dut.name, new File(testDirPath), Seq(), new File(cppHarnessFileName)).!
     Chisel.Driver.cppToExe(verilogFileName.split("\\.")(0), new File(testDirPath)).!
 
     new VerilatorBackend(dut, cppBinaryPath)

--- a/src/main/scala/Chisel/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/Chisel/iotesters/VerilatorBackend.scala
@@ -37,13 +37,13 @@ private[iotesters] object setupVerilatorBackend {
     Chisel.Driver.verilogToCpp(verilogFileName.split("\\.")(0), dut.name, new File(testDirPath), Seq(), new File(cppHarnessFileName)).!
     Chisel.Driver.cppToExe(verilogFileName.split("\\.")(0), new File(testDirPath)).!
 
-    new VerilatorBackend(dut, cppBinaryPath)
+    new VerilatorBackend(dut, List(cppBinaryPath))
   }
 }
 
 private[iotesters] class VerilatorBackend(
                                           dut: Module, 
-                                          cmd: String,
+                                          cmd: List[String],
                                           verbose: Boolean = true,
                                           logger: PrintStream = System.out,
                                           _base: Int = 16,


### PR DESCRIPTION
Added more features in PeekPokeTester including:
1. Add a flag(--noUpdate) not to propagate the output values of sequential logics
2. Add a flag(--logFile) and a parameter to dump the tester logs to a file instead of the screen
3. Add a flag(--waveform) and a parameter to change the waveform file name