### PR TITLE
Change firrtl file suffix to be ".ir"

### DIFF
--- a/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
+++ b/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
@@ -27,7 +27,7 @@ private[iotesters] class FirrtlTerpBackend(
       case port: Bits =>
         val name = portNames(port)
         interpretiveTester.poke(name, value)
-        if (verbose) logger println s"  POKE ${name} <- ${bigIntToStr(value, _base)}"
+        if (verbose) logger println s"  POKE $name <- ${bigIntToStr(value, _base)}"
       case _ =>
     }
   }
@@ -37,7 +37,7 @@ private[iotesters] class FirrtlTerpBackend(
       case port: Bits =>
         val name = portNames(port)
         val result = interpretiveTester.peek(name)
-        if (verbose) logger println s"  PEEK ${name} -> ${bigIntToStr(result, _base)}"
+        if (verbose) logger println s"  PEEK $name -> ${bigIntToStr(result, _base)}"
         result
       case _ => BigInt(rnd.nextInt)
     }
@@ -49,7 +49,7 @@ private[iotesters] class FirrtlTerpBackend(
         val name = portNames(port)
         val got = interpretiveTester.peek(name)
         val good = got == expected
-        if (verbose) logger println s"""${msg}  EXPECT ${name} -> ${bigIntToStr(got, _base)} == ${bigIntToStr(expected, _base)} ${if (good) "PASS" else "FAIL"}"""
+        if (verbose) logger println s"""$msg  EXPECT $name -> ${bigIntToStr(got, _base)} == ${bigIntToStr(expected, _base)} ${if (good) "PASS" else "FAIL"}"""
         good
       case _ => false
     }
@@ -90,7 +90,7 @@ private[iotesters] object setupFirrtlTerpBackend {
     val dir = new File(s"test_run_dir/${dut.getClass.getName}") ; dir.mkdirs()
 
     // Dump FIRRTL for debugging
-    val firrtlIRFile = new File(dir, s"${circuit.name}.ir")
+    val firrtlIRFile = new File(dir, s"${circuit.name}.fir")
     chisel3.Driver.dumpFirrtl(circuit, Some(firrtlIRFile))
     val firrtlIR = chisel3.Driver.emit(dutGen)
 

--- a/src/test/scala/examples/GCDSpec.scala
+++ b/src/test/scala/examples/GCDSpec.scala
@@ -1,0 +1,89 @@
+// See LICENSE for license details.
+
+package examples
+
+import chisel3._
+import chisel3.util._
+import chisel3.iotesters._
+import org.scalatest.{Matchers, FlatSpec}
+
+object RealGCD2 {
+  val num_width = 16
+}
+
+class RealGCD2Input extends Bundle {
+  val a = Bits(width = RealGCD2.num_width)
+  val b = Bits(width = RealGCD2.num_width)
+}
+
+class RealGCD2 extends Module {
+  val io  = new Bundle {
+    val in  = Decoupled(new RealGCD2Input()).flip()
+    val out = Valid(UInt(width = RealGCD2.num_width))
+  }
+
+  val x = Reg(UInt(width = RealGCD2.num_width))
+  val y = Reg(UInt(width = RealGCD2.num_width))
+  val p = Reg(init=Bool(false))
+
+  val ti = Reg(init=UInt(0, width = RealGCD2.num_width))
+  ti := ti + UInt(1)
+
+  io.in.ready := !p
+
+  when (io.in.valid && !p) {
+    x := io.in.bits.a
+    y := io.in.bits.b
+    p := Bool(true)
+  }
+
+  when (p) {
+    when (x > y)  { x := y; y := x }
+      .otherwise    { y := y - x }
+  }
+
+  printf("ti %d  x %d y %d  in_ready %d  in_valid %d  out %d out_valid %d==============\n",
+    ti, x, y, io.in.ready, io.in.valid, io.out.bits, io.out.valid)
+  //      ti, x, y, io.in.ready, io.in.valid, io.out.bits, io.out.ready, io.out.valid)
+
+  io.out.bits  := x
+  io.out.valid := y === Bits(0) && p
+  when (io.out.valid) {
+    p := Bool(false)
+  }
+}
+
+class GCDPeekPokeTester(c: RealGCD2) extends PeekPokeTester(c)  {
+  for {
+    i <- 1 to 10
+    j <- 1 to 10
+  } {
+    val (gcd_value, cycles) = GCDCalculator.computeGcdResultsAndCycles(i, j)
+
+    poke(c.io.in.bits.a, i)
+    poke(c.io.in.bits.b, j)
+    poke(c.io.in.valid, 1)
+
+    var count = 0
+    while(peek(c.io.out.valid) == BigInt(0) && count < 20) {
+      step(1)
+      count += 1
+    }
+    if(count > 30) {
+      println(s"Waited $count cycles on gcd inputs $i, $j, giving up")
+      System.exit(0)
+    }
+    expect(c.io.out.bits, gcd_value)
+    step(1)
+  }
+}
+class GCDSpec extends FlatSpec with Matchers {
+  behavior of "GCDSpec"
+
+  it should "compute gcd excellently" in {
+    chisel3.iotesters.Driver(() => new RealGCD2) { c =>
+      new GCDPeekPokeTester(c)
+    } should be(true)
+  }
+}
+

--- a/src/test/scala/examples/Router.scala
+++ b/src/test/scala/examples/Router.scala
@@ -150,7 +150,7 @@ class RouterUnitTester(number_of_packets_to_send: Int) extends OrderedDecoupledH
 
 class RouterUnitTesterSpec extends ChiselFlatSpec {
   val number_of_packets = 20
-  "a router" should "can have it's rout table loaded and changed and route a bunch of packets" ignore {
+  "a router" should "can have it's rout table loaded and changed and route a bunch of packets" in {
     assertTesterPasses {
       new RouterUnitTester(number_of_packets)
     }


### PR DESCRIPTION
firrtl intermediate files now have correct suffix ".fir"
Add a version of GCDSpec that uses PeekPokeTester