### PR TITLE
change signal name for verilator 3.886

### DIFF
--- a/src/main/scala/chisel3/iotesters/ChiselMain.scala
+++ b/src/main/scala/chisel3/iotesters/ChiselMain.scala
@@ -71,14 +71,14 @@ object chiselMain {
         // Copy API files
         copyVerilatorHeaderFiles(context.targetDir.toString)
         // Generate Verilator
-        chisel3.Driver.verilogToCpp(dutName, dutName, dir, Seq(), new File(s"$dutName-harness.cpp")).!
+        assert(chisel3.Driver.verilogToCpp(dutName, dutName, dir, Seq(), new File(s"$dutName-harness.cpp")).! == 0)
         // Compile Verilator
-        chisel3.Driver.cppToExe(dutName, dir).!
+        assert(chisel3.Driver.cppToExe(dutName, dir).! == 0)
       case "vcs" | "glsim" =>
         // Copy API files
         copyVpiFiles(context.targetDir.toString)
         // Compile VCS
-        verilogToVCS(dutName, dir, new File(s"$dutName-harness.v")).!
+        assert(verilogToVCS(dutName, dir, new File(s"$dutName-harness.v")).! == 0)
       case b => throw BackendException(b)
     }
   }

--- a/src/main/scala/chisel3/iotesters/VCSBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VCSBackend.scala
@@ -135,7 +135,7 @@ private[iotesters] object setupVCSBackend {
     val vpdFile = new File(dir, s"${circuit.name}.vpd")
     copyVpiFiles(dir.toString)
     genVCSVerilogHarness(dut, new FileWriter(vcsHarnessFile), vpdFile.toString)
-    verilogToVCS(circuit.name, dir, new File(vcsHarnessFileName)).!
+    assert(verilogToVCS(circuit.name, dir, new File(vcsHarnessFileName)).! == 0)
 
     (dut, new VCSBackend(dut, Seq((new File(dir, circuit.name)).toString)))
   }

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -289,8 +289,8 @@ private[iotesters] object setupVerilatorBackend {
     copyVerilatorHeaderFiles(dir.toString)
     harnessCompiler.compile(chirrtl, annotation, cppHarnessWriter)
     cppHarnessWriter.close
-    chisel3.Driver.verilogToCpp(circuit.name, circuit.name, dir, Seq(), new File(cppHarnessFileName)).!
-    chisel3.Driver.cppToExe(circuit.name, dir).!
+    assert(chisel3.Driver.verilogToCpp(circuit.name, circuit.name, dir, Seq(), new File(cppHarnessFileName)).! == 0)
+    assert(chisel3.Driver.cppToExe(circuit.name, dir).! == 0)
 
     (dut, new VerilatorBackend(dut, Seq((new File(dir, s"V${circuit.name}")).toString)))
   }

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -133,7 +133,7 @@ class GenVerilatorCppHarness(writer: Writer, dut: Chisel.Module,
     writer.write(s"""        sim_data.signal_map["%s"] = 0;\n""".format(dut.reset.pathName))
     (nodes foldLeft 1){ (id, node) =>
       val instanceName = s"%s.%s".format(node.parentPathName, validName(node.instanceName))
-      val pathName = instanceName replace (dutName, "v") replace (".", "__DOT__") replace ("$", "__024")
+      val pathName = instanceName replace (".", "__DOT__") replace ("$", "__024")
       try {
         node match {
           case mem: Chisel.MemBase[_] =>


### PR DESCRIPTION
Signal names start with its top module name, not with 'v'