### PR TITLE
Use TesterOptions verbose instead of the argument.

### DIFF
--- a/src/main/scala/chisel3/iotesters/AdvTester.scala
+++ b/src/main/scala/chisel3/iotesters/AdvTester.scala
@@ -21,10 +21,9 @@ trait AdvTests extends PeekPokeTests {
 }
 
 abstract class AdvTester[+T <: Module](dut: T,
-                                       verbose: Boolean = false,
                                        base: Int = 16,
                                        logFile: Option[java.io.File] = chiselMain.context.logFile)
-                extends PeekPokeTester(dut, verbose, base, logFile) {
+                extends PeekPokeTester(dut, base, logFile) {
   val defaultMaxCycles = 1024L
   var _cycles = 0L
   def cycles = _cycles

--- a/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
@@ -92,7 +92,7 @@ abstract class PeekPokeTester[+T <: Module](
   }
 
   def step(n: Int) {
-    if (verbose) logger println s"STEP $simTime -> ${simTime+n}"
+    if (_verbose) logger println s"STEP $simTime -> ${simTime+n}"
     backend.step(n)
     incTime(n)
   }
@@ -197,7 +197,7 @@ abstract class PeekPokeTester[+T <: Module](
   }
 
   def expect (good: Boolean, msg: => String): Boolean = {
-    if (verbose) logger println s"""EXPECT $msg ${if (good) "PASS" else "FAIL"}"""
+    if (_verbose) logger println s"""EXPECT $msg ${if (good) "PASS" else "FAIL"}"""
     if (!good) fail
     good
   }

--- a/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
@@ -34,7 +34,6 @@ trait PeekPokeTests {
 
 abstract class PeekPokeTester[+T <: Module](
     val dut: T,
-    verbose: Boolean = true,
     base: Int = 16,
     logFile: Option[File] = None) {
 


### PR DESCRIPTION
Should we remove `verbose` as an argument to the PeekPokeTester constructor? Related to #54 
