### PR TITLE
change default directory for tester 

### DIFF
--- a/src/main/scala/chisel3/iotesters/Driver.scala
+++ b/src/main/scala/chisel3/iotesters/Driver.scala
@@ -24,6 +24,14 @@ object Driver {
                           (
                             testerGen: T => PeekPokeTester[T]
                           ): Boolean = {
+    if(optionsManager.topName.isEmpty) {
+      if(optionsManager.targetDirName == ".") {
+        optionsManager.setTargetDirName("test_run_dir")
+      }
+      val genClassName = testerGen.getClass.getName
+      val testerName = genClassName.split("""\$\$""").headOption.getOrElse("") + genClassName.hashCode.abs
+      optionsManager.setTargetDirName(s"${optionsManager.targetDirName}/$testerName")
+    }
     val testerOptions = optionsManager.testerOptions
 
     val (dut, backend) = testerOptions.backendName match {
@@ -37,23 +45,17 @@ object Driver {
         throw new Exception(s"Unrecognized backend name ${testerOptions.backendName}")
     }
 
-    if(optionsManager.topName.isEmpty) {
-      optionsManager.setTargetDirName(s"${optionsManager.targetDirName}/${testerGen.getClass.getName}")
-    }
-    optionsManagerVar.withValue(Some(optionsManager)) {
-      backendVar.withValue(Some(backend)) {
-        try {
-          testerGen(dut).finish
-        } catch {
-          case e: Throwable =>
-            e.printStackTrace()
-            backend match {
-              case b: VCSBackend => TesterProcess.kill(b)
-              case b: VerilatorBackend => TesterProcess.kill(b)
-              case _ =>
-            }
-            throw e
+    backendVar.withValue(Some(backend)) {
+      try {
+        testerGen(dut).finish
+      } catch { case e: Throwable =>
+        e.printStackTrace()
+        backend match {
+          case b: VCSBackend => TesterProcess.kill(b)
+          case b: VerilatorBackend => TesterProcess.kill(b)
+          case _ =>
         }
+        throw e
       }
     }
   }
@@ -107,6 +109,36 @@ object Driver {
       case ChiselExecutionFailure(message) =>
         println("Failed to compile circuit")
         false
+    }
+  }
+  /**
+    * Start up the interpreter repl with the given circuit
+    * To test a `class X extends Module {}`, add the following code to the end
+    * of the file that defines
+    * @example {{{
+    *           object XRepl {
+    *             def main(args: Array[String]) {
+    *               iotesters.Driver.executeFirrtlRepl(args, () => new X)
+    *             }
+    *           }
+    * }}}
+    * running main will place users in the repl with the circuit X loaded into the repl
+    *
+    * @param dutGenerator   Module to run in interpreter
+    * @param args           options from the command line
+    * @return
+    */
+  def executeFirrtlRepl[T <: Module](
+                                    args: Array[String],
+                                      dutGenerator: () => T
+                                      ): Boolean = {
+    val optionsManager = new ReplOptionsManager
+
+    if(optionsManager.parse(args)) {
+      executeFirrtlRepl(dutGenerator, optionsManager)
+    }
+    else {
+      false
     }
   }
   /**

--- a/src/test/scala/examples/GCDSpec.scala
+++ b/src/test/scala/examples/GCDSpec.scala
@@ -90,7 +90,7 @@ class GCDSpec extends FlatSpec with Matchers {
   behavior of "GCDSpec"
 
   it should "compute gcd excellently" in {
-    chisel3.iotesters.Driver(() => new RealGCD2) { c =>
+    iotesters.Driver.execute(() => new RealGCD2, new TesterOptionsManager) { c =>
       new GCDPeekPokeTester(c)
     } should be(true)
   }


### PR DESCRIPTION
to be test_run_dir/<sanitized-spe…c-classname><hashcode>
It's just to hard to pick up dut class name without double elaborating, so this should be a decent compromise. Adding hashcode makes separate directories for multiple tests within the same spec file which seems better