### PR TITLE
Fix some typos.

### DIFF
--- a/src/main/scala/chisel3/iotesters/Driver.scala
+++ b/src/main/scala/chisel3/iotesters/Driver.scala
@@ -66,7 +66,6 @@ object Driver {
     optionsManager.parse(args) match {
       case true =>
         execute(dut, optionsManager)(testerGen)
-        true
       case _ =>
         false
     }

--- a/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
@@ -107,7 +107,7 @@ private[iotesters] case class TestApplicationException(exitVal: Int, lastMessage
 
 private[iotesters] object TesterProcess {
   def apply(cmd: Seq[String], logs: ArrayBuffer[String]) = {
-    require(new java.io.File(cmd.head).exists, s"${cmd.head} doesn't exists")
+    require(new java.io.File(cmd.head).exists, s"${cmd.head} doesn't exist")
     val processBuilder = Process(cmd mkString " ")
     val processLogger = ProcessLogger(println, logs += _) // don't log stdout
     processBuilder run processLogger


### PR DESCRIPTION
One resulted in one of the Driver's execute methods always returning
true (PASS).

One was just a typo on a printed message.