### PR TITLE
Fixed problem with lack of reporting of failed tests

### DIFF
--- a/src/main/scala/chisel3/iotesters/Driver.scala
+++ b/src/main/scala/chisel3/iotesters/Driver.scala
@@ -22,7 +22,7 @@ object Driver {
     *
     * @param dutGenerator    The device under test, a subclass of a Chisel3 module
     * @param optionsManager  Use this to control options like which backend to use
-    * @param testerGen       A peek poke tester with tests fro the dut
+    * @param testerGen       A peek poke tester with tests for the dut
     * @return                Returns true if all tests in testerGen pass
     */
   def execute[T <: Module](

--- a/src/main/scala/chisel3/iotesters/Driver.scala
+++ b/src/main/scala/chisel3/iotesters/Driver.scala
@@ -16,7 +16,15 @@ object Driver {
   private val optionsManagerVar = new DynamicVariable[Option[TesterOptionsManager]](None)
   private[iotesters] def optionsManager = optionsManagerVar.value.getOrElse(new TesterOptionsManager)
 
-
+  /**
+    * This executes a test harness that extends peek-poke tester upon a device under test
+    * with an optionsManager to control all the options of the toolchain components
+    *
+    * @param dutGenerator    The device under test, a subclass of a Chisel3 module
+    * @param optionsManager  Use this to control options like which backend to use
+    * @param testerGen       A peek poke tester with tests fro the dut
+    * @return                Returns true if all tests in testerGen pass
+    */
   def execute[T <: Module](
                             dutGenerator: () => T,
                             optionsManager: TesterOptionsManager
@@ -58,6 +66,15 @@ object Driver {
     }
   }
 
+  /**
+    * This executes the test with options provide from an array of string -- typically provided from the
+    * command line
+    *
+    * @param args       A *main* style array of string options
+    * @param dut        The device to be tested, (device-under-test)
+    * @param testerGen  A peek-poke tester with test for the dey
+    * @return           Returns true if all tests in testerGen pass
+    */
   def execute[T <: Module](args: Array[String], dut: () => T)(
     testerGen: T => PeekPokeTester[T]
   ): Boolean = {
@@ -76,6 +93,7 @@ object Driver {
     * Start up the interpreter repl with the given circuit
     * To test a `class X extends Module {}`, add the following code to the end
     * of the file that defines
+    *
     * @example {{{
     *           object XRepl {
     *             def main(args: Array[String]) {
@@ -86,7 +104,6 @@ object Driver {
     *             }
     * }}}
     * running main will place users in the repl with the circuit X loaded into the repl
-    *
     * @param dutGenerator   Module to run in interpreter
     * @param optionsManager options
     * @return
@@ -121,32 +138,45 @@ object Driver {
   }
   /**
     * Runs the ClassicTester and returns a Boolean indicating test success or failure
-    * @@backendType determines whether the ClassicTester uses verilator or the firrtl interpreter to simulate the circuit
-    * Will do intermediate compliation steps to setup the backend specified, including cpp compilation for the verilator backend and firrtl IR compilation for the firrlt backend
-    */
-  def apply[T <: Module](dutGen: () => T, backendType: String = "firrtl")(
-      testerGen: T => PeekPokeTester[T]): Boolean = {
-    val optionsManager = new TesterOptionsManager
+    * @@backendType determines whether the ClassicTester uses verilator or the firrtl interpreter to simulate
+    * the circuit.
+    * Will do intermediate compliation steps to setup the backend specified, including cpp compilation for the
+    * verilator backend and firrtl IR compilation for the firrlt backend
+    *
+    * This apply method is a convenient short form of the [[Driver.execute()]] which has many more options
+    *
+    * The following tests a chisel CircuitX with a CircuitXTester setting the random number seed to a fixed value and
+    * turning on verbose tester output.  The result of the overall test is put in testsPassed
+    *
+    * @example {{{
+    *           val testsPassed = iotesters.Driver(() => new CircuitX, testerSeed = 0L, verbose = true) { circuitX =>
+    *             CircuitXTester(circuitX)
+    *           }
+    * }}}
+    *
 
-    val (dut, backend) = backendType match {
-      case "firrtl"    => setupFirrtlTerpBackend(dutGen, optionsManager)
-      case "verilator" => setupVerilatorBackend(dutGen, optionsManager)
-      case "vcs"       => setupVCSBackend(dutGen, optionsManager)
-      case _ => throw new Exception("Unrecongnized backend type $backendType")
+    * @param dutGen      This is the device under test.
+    * @param backendType The default backend is "firrtl" which uses the firrtl interperter. Other options
+    *                    "verilator" will use the verilator c++ simulation generator
+    *                    "vcs" will use the VCS simulation
+    * @param verbose     Setting this to true will make the tester display information on peeks,
+    *                    pokes, steps, and expects.  By default only failed expects will be printed
+    * @param testerSeed  Set the random number generator seed
+    * @param testerGen   This is a test harness subclassing PeekPokeTester for dutGen,
+    * @return            This will be true if all tests in the testerGen pass
+    */
+  def apply[T <: Module](
+      dutGen: () => T,
+      backendType: String = "firrtl",
+      verbose: Boolean = false,
+      testerSeed: Long = System.currentTimeMillis())(
+      testerGen: T => PeekPokeTester[T]): Boolean = {
+
+    val optionsManager = new TesterOptionsManager {
+      testerOptions = testerOptions.copy(backendName = backendType, isVerbose = verbose, testerSeed = testerSeed)
     }
-    backendVar.withValue(Some(backend)) {
-      try {
-        testerGen(dut).finish
-      } catch { case e: Throwable =>
-        e.printStackTrace()
-        backend match {
-          case b: VCSBackend => TesterProcess.kill(b)
-          case b: VerilatorBackend => TesterProcess.kill(b)
-          case _ =>
-        }
-        throw e
-      }
-    }
+
+    execute(dutGen, optionsManager)(testerGen)
   }
 
   /**

--- a/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
+++ b/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
@@ -48,9 +48,10 @@ private[iotesters] class FirrtlTerpBackend(
         val name = portNames(port)
         val got = interpretiveTester.peek(name)
         val good = got == expected
-        if (verbose) logger println
-           s"""$msg  EXPECT $name -> ${bigIntToStr(got, base)} == ${bigIntToStr(expected, base)}""" +
+        if (verbose || !good) logger println
+           s"""EXPECT AT $stepNumber $msg  $name -> ${bigIntToStr(got, base)} == ${bigIntToStr(expected, base)}""" +
            s""" ${if (good) "PASS" else "FAIL"}"""
+        if(good) interpretiveTester.expectationsMet += 1
         good
       case _ => false
     }
@@ -73,7 +74,10 @@ private[iotesters] class FirrtlTerpBackend(
     false
   }
 
+  private var stepNumber: Long = 0L
+
   def step(n: Int)(implicit logger: PrintStream): Unit = {
+    stepNumber += n
     interpretiveTester.step(n)
   }
 

--- a/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
@@ -191,12 +191,12 @@ abstract class PeekPokeTester[+T <: Module](
     bigIntMap
   }
 
-  def peekAt[T <: Bits](data: Mem[T], off: Int): BigInt = {
+  def peekAt[TT <: Bits](data: Mem[TT], off: Int): BigInt = {
     backend.peek(data, Some(off))
   }
 
   def expect (good: Boolean, msg: => String): Boolean = {
-    if (_verbose) logger println s"""EXPECT $msg ${if (good) "PASS" else "FAIL"}"""
+    if (_verbose || ! good) logger println s"""EXPECT AT $simTime $msg ${if (good) "PASS" else "FAIL"}"""
     if (!good) fail
     good
   }


### PR DESCRIPTION
Add comments on Driver.execute methods
Made Driver.apply use underlying execute methods and provide a couple more useful
options it can set: verbose and testerSeed.  It should be default way of invoking tests
unless need for more backend toolchain option control pushes user towards execute methods
Add step number to expect messages
Fixed number of successful expects not be counted in interpreter based tester
Failed expects print even if verbose is off
Fixed type shadowing on PeekPokeTester peekAt