### PR TITLE
Fix poke expect neg ints

### DIFF
--- a/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
+++ b/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
@@ -29,6 +29,11 @@ private[iotesters] class FirrtlTerpBackend(
     }
   }
 
+  def poke(signal: InstanceId, value: Int, off: Option[Int])
+          (implicit logger: PrintStream, verbose: Boolean, base: Int): Unit = {
+    poke(signal, BigInt(value), off)
+  }
+
   def peek(signal: InstanceId, off: Option[Int])
           (implicit logger: PrintStream, verbose: Boolean, base: Int): BigInt = {
     signal match {
@@ -55,6 +60,11 @@ private[iotesters] class FirrtlTerpBackend(
         good
       case _ => false
     }
+  }
+
+  def expect(signal: InstanceId, expected: Int, msg: => String)
+            (implicit logger: PrintStream, verbose: Boolean, base: Int) : Boolean = {
+    expect(signal,BigInt(expected), msg)
   }
 
   def poke(path: String, value: BigInt)

--- a/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
@@ -96,13 +96,22 @@ abstract class PeekPokeTester[+T <: Module](
     incTime(n)
   }
 
-  def poke(path: String, value: BigInt) = backend.poke(path, value)
+  def poke(path: String, value: BigInt): Unit = {
+    backend.poke(path, value)
+  }
+  def poke(path: String, value: Int): Unit = {
+    poke(path, BigInt(value))
+  }
 
   def peek(path: String) = backend.peek(path)
 
-  def poke(signal: Bits, value: BigInt) {
+  def poke(signal: Bits, value: BigInt): Unit = {
     if (!signal.isLit) backend.poke(signal, value, None)
     // TODO: Warn if signal.isLit
+  }
+
+  def poke(signal: Bits, value: Int) {
+    poke(signal, BigInt(value))
   }
 
   /** Locate a specific bundle element, given a name path.
@@ -207,6 +216,10 @@ abstract class PeekPokeTester[+T <: Module](
       if (!good) fail
       good
     } else expect(signal.litValue() == expected, s"${signal.litValue()} == $expected")
+  }
+
+  def expect(signal: Bits, expected: Int, msg: => String): Boolean = {
+    expect(signal, BigInt(expected), msg)
   }
 
   def expect (signal: Aggregate, expected: IndexedSeq[BigInt]): Boolean = {

--- a/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
@@ -82,6 +82,20 @@ abstract class PeekPokeTester[+T <: Module](
   /** Convert Bits to BigInt */
   implicit def int(x: Bits):    BigInt = x.litValue()
 
+  /**
+    * Convert an Int to unsigned (effectively 32-bit) BigInt
+    * @param x  number to be converted
+    * @return
+    */
+  def intToUnsignedBigInt(x: Int): BigInt = (BigInt(x >>> 1) << 1) | BigInt(x & 1)
+
+  /**
+    * Convert an Int to unsigned (effectively 64-bit) BigInt
+    * @param x long to be converted
+    * @return
+    */
+  def longToUnsignedBigInt(x: Long): BigInt = (BigInt(x >>> 1) << 1) | BigInt(x & 1)
+
   def reset(n: Int = 1) {
     backend.reset(n)
   }

--- a/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
@@ -79,10 +79,6 @@ abstract class PeekPokeTester[+T <: Module](
 
   /** Convert a Boolean to BigInt */
   implicit def int(x: Boolean): BigInt = if (x) 1 else 0
-  /** Convert an Int to BigInt */
-  implicit def int(x: Int):     BigInt = (BigInt(x >>> 1) << 1) | BigInt(x & 1)
-  /** Convert a Long to BigInt */
-  implicit def int(x: Long):    BigInt = (BigInt(x >>> 1) << 1) | BigInt(x & 1)
   /** Convert Bits to BigInt */
   implicit def int(x: Bits):    BigInt = x.litValue()
 

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -322,6 +322,11 @@ private[iotesters] class VerilatorBackend(dut: Chisel.Module,
     poke(path, value)
   }
 
+  def poke(signal: InstanceId, value: Int, off: Option[Int])
+          (implicit logger: PrintStream, verbose: Boolean, base: Int) {
+    poke(signal, BigInt(value), off)
+  }
+
   def peek(signal: InstanceId, off: Option[Int])
           (implicit logger: PrintStream, verbose: Boolean, base: Int): BigInt = {
     val idx = off map (x => s"[$x]") getOrElse ""
@@ -335,10 +340,20 @@ private[iotesters] class VerilatorBackend(dut: Chisel.Module,
     expect(path, expected, msg)
   }
 
+  def expect(signal: InstanceId, expected: Int, msg: => String)
+            (implicit logger: PrintStream, verbose: Boolean, base: Int): Boolean = {
+    expect(signal, BigInt(expected), msg)
+  }
+
   def poke(path: String, value: BigInt)
           (implicit logger: PrintStream, verbose: Boolean, base: Int) {
     if (verbose) logger println s"  POKE ${path} <- ${bigIntToStr(value, base)}"
     simApiInterface.poke(path, value)
+  }
+
+  def poke(path: String, value: Int)
+          (implicit logger: PrintStream, verbose: Boolean, base: Int) {
+    poke(path, BigInt(value))
   }
 
   def peek(path: String)
@@ -354,8 +369,13 @@ private[iotesters] class VerilatorBackend(dut: Chisel.Module,
     val good = got == expected
     if (verbose) logger println (
       s"""${msg}  EXPECT ${path} -> ${bigIntToStr(got, base)} == """ +
-      s"""${bigIntToStr(expected, base)} ${if (good) "PASS" else "FAIL"}""")
+        s"""${bigIntToStr(expected, base)} ${if (good) "PASS" else "FAIL"}""")
     good
+  }
+
+  def expect(path: String, expected: Int, msg: => String)
+            (implicit logger: PrintStream, verbose: Boolean, base: Int): Boolean = {
+    expect(path, BigInt(expected), msg)
   }
 
   def step(n: Int)(implicit logger: PrintStream): Unit = {


### PR DESCRIPTION
Problem was implicit conversion of negative ints to positive BigInt representation.
Removed the implicits after discussion with @donggyukim 
This is a simpler more elegant fix that in PR #63 
Seems to works with dsptool tests that exposed this bug originally