### PR TITLE
Ignore lib (for rocket build)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -423,3 +423,4 @@ project/plugins/project/
 .scala_dependencies
 .worksheet
 
+/lib


### PR DESCRIPTION
It's helpful for me if git ignores /lib added by dsp-framework and/or craft2-chip