### PR TITLE
More ScalaTest-y specs

### DIFF
--- a/src/main/scala/chisel3/iotesters/ChiselPokeSpec.scala
+++ b/src/main/scala/chisel3/iotesters/ChiselPokeSpec.scala
@@ -26,7 +26,7 @@ case object VcsBackend extends TesterBackend {
   }
 }
 
-trait ChiselPokeUtils extends Assertions {
+trait ChiselPokeTesterUtils extends Assertions {
   class InnerTester(val backend: Backend, val options: TesterOptionsManager) {
     // Implicit configuration options for backend
     implicit val logger = System.out  // TODO: this should be parsed in OptionsManager
@@ -101,7 +101,7 @@ trait ChiselPokeUtils extends Assertions {
 
 /** Basic peek-poke test system where failures are handled and reported within ScalaTest.
   */
-class ChiselPokeSpec extends FlatSpec with ChiselPokeUtils {
+trait PokeTester extends ChiselPokeTesterUtils {
   def run[T <: Module](dutGen: => T, testerBackend: TesterBackend=FirrtlInterpreterBackend)(block: (InnerTester, T) => Unit) {
     runTester(dutGen, testerBackend) { (tester, dut) => block(tester, dut) }
   }
@@ -112,7 +112,7 @@ class ChiselPokeSpec extends FlatSpec with ChiselPokeUtils {
   *
   * API very subject to change.
   */
-class ChiselImplicitPokeSpec extends FlatSpec with ChiselPokeUtils {
+trait ImplicitPokeTester extends ChiselPokeTesterUtils {
   // Optional chain-through giving lightweight syntax for those unafraid of implicits.
   implicit class BitsTestable(ref: Bits) {
     /** Shorthand for assert(peek(ref) === value).

--- a/src/main/scala/chisel3/iotesters/ChiselPokeSpec.scala
+++ b/src/main/scala/chisel3/iotesters/ChiselPokeSpec.scala
@@ -1,0 +1,137 @@
+// See LICENSE for license details.
+
+package chisel3.iotesters.experimental
+
+import org.scalatest._
+
+import chisel3._
+import chisel3.iotesters._
+
+sealed trait TesterBackend {
+  def create[T <: Module](dutGen: () => T, options: TesterOptionsManager): (T, Backend)
+}
+case object FirrtlInterpreterBackend extends TesterBackend {
+  override def create[T <: Module](dutGen: () => T, options: TesterOptionsManager): (T, Backend) = {
+    setupFirrtlTerpBackend(dutGen, options)
+  }
+}
+case object VerilatorBackend extends TesterBackend {
+  override def create[T <: Module](dutGen: () => T, options: TesterOptionsManager): (T, Backend) = {
+    setupVerilatorBackend(dutGen, options)
+  }
+}
+case object VcsBackend extends TesterBackend {
+  override def create[T <: Module](dutGen: () => T, options: TesterOptionsManager): (T, Backend) = {
+    setupVCSBackend(dutGen, options)
+  }
+}
+
+trait ChiselPokeUtils extends Assertions {
+  class InnerTester(val backend: Backend, val options: TesterOptionsManager) {
+    // Implicit configuration options for backend
+    implicit val logger = System.out  // TODO: this should be parsed in OptionsManager
+    implicit val verbose = options.testerOptions.isVerbose
+    implicit val displayBase = options.testerOptions.displayBase
+
+    // Circuit state
+    private var currCycle = 0
+
+    // TODO: statically-typed Bundle constructors
+    // Map-based Bundle expect/pokes currently not supported because those don't compile-time check
+
+    def expect(ref: Bits, value: BigInt, msg: String="") {
+      val actualValue = backend.peek(ref, None)
+      val postfix = if (msg != "") s": $msg" else ""
+      assert(actualValue == value, s"expect failure on cycle $currCycle, expected ${ref.instanceName} == $value, got $actualValue$postfix")
+    }
+
+    /** Write a value into the circuit.
+      */
+    def poke(ref: Bits, value: BigInt) {
+      assert(!ref.isLit, "attempted to poke literal")
+      backend.poke(ref, value, None)
+      val verifyVal = backend.peek(ref, None)
+      assert(verifyVal == value, s"poke failed on ${ref.instanceName}, verify expected $value, got $verifyVal")
+    }
+
+    /** Steps the circuit by the specified number of clock cycles.
+      */
+    def step(cycles: Int = 1) {
+      require(cycles > 0)
+      backend.step(cycles)
+      currCycle += cycles
+    }
+
+    /** Hold the circuit in reset for the specified number of clock cycles.
+      */
+    def reset(cycles: Int = 1) {
+      require(cycles > 0)
+      backend.reset(cycles)
+      currCycle += cycles
+    }
+
+    private[iotesters] def finish {
+      try {
+        backend.finish
+      } catch {
+        case e: TestApplicationException => assert(e.exitVal == 0, s"nonzero simulator exit code ${e.exitVal}")
+      }
+    }
+
+    // Explicitly no peek is given to allow generation of static testbenches.
+    // Dynamic testbenches may be a specialized option later.
+    /** Internal: read a value into the circuit.
+      */
+    private[iotesters] def peek(ref: Bits): BigInt = {
+      backend.peek(ref, None)
+    }
+  }
+
+  /** Instantiates a tester from a module generator, using default Tester options.
+    */
+  protected def runTester[T <: Module](dutGen: => T, testerBackend: TesterBackend=FirrtlInterpreterBackend)(block: (InnerTester, T) => Unit) {
+    val optionsManager = new TesterOptionsManager
+    val dutGenShim: () => T = () => dutGen
+    val (dut, backend) = testerBackend.create(dutGenShim, optionsManager)
+    val innerTester = new InnerTester(backend, optionsManager)
+    block(innerTester, dut)
+    innerTester.finish
+  }
+}
+
+/** Basic peek-poke test system where failures are handled and reported within ScalaTest.
+  */
+class ChiselPokeSpec extends FlatSpec with ChiselPokeUtils {
+  def run[T <: Module](dutGen: => T, testerBackend: TesterBackend=FirrtlInterpreterBackend)(block: (InnerTester, T) => Unit) {
+    runTester(dutGen, testerBackend) { (tester, dut) => block(tester, dut) }
+  }
+}
+
+/** EXPERIMENTAL test system that provides a more ScalaTest-ey way of specifying tests, making
+  * heavy use of implicits to reduce boilerplate.
+  *
+  * API very subject to change.
+  */
+class ChiselImplicitPokeSpec extends FlatSpec with ChiselPokeUtils {
+  // Optional chain-through giving lightweight syntax for those unafraid of implicits.
+  implicit class BitsTestable(ref: Bits) {
+    def ?==(value: BigInt)(implicit t: InnerTester): Boolean = {
+      t.peek(ref) == value
+    }
+
+    def <<=(value: BigInt)(implicit t: InnerTester) {
+      t.poke(ref, value)
+    }
+  }
+
+  def step(cycles: Int = 1)(implicit t: InnerTester) {
+    t.step(cycles)
+  }
+  def reset(cycles: Int = 1)(implicit t: InnerTester) {
+    t.reset(cycles)
+  }
+
+  def run[T <: Module](dutGen: => T, testerBackend: TesterBackend=FirrtlInterpreterBackend)(block: InnerTester => (T => Unit)) {
+    runTester(dutGen, testerBackend) { (tester, dut) => block(tester)(dut) }
+  }
+}

--- a/src/main/scala/chisel3/iotesters/ChiselPokeSpec.scala
+++ b/src/main/scala/chisel3/iotesters/ChiselPokeSpec.scala
@@ -127,6 +127,30 @@ trait ImplicitPokeTester extends ChiselPokeTesterUtils {
     }
   }
 
+  implicit class BoolTestable(ref: Bool) {
+    def ?==(value: BigInt)(implicit t: InnerTester) {
+      t.expect(ref, value)
+    }
+
+    def <<=(value: BigInt)(implicit t: InnerTester) {
+      t.poke(ref, value)
+    }
+
+    def ?==(value: Boolean)(implicit t: InnerTester) {
+      value match {
+        case true => t.expect(ref, 1)
+        case false => t.expect(ref, 0)
+      }
+    }
+
+    def <<=(value: Boolean)(implicit t: InnerTester) {
+      value match {
+        case true => t.poke(ref, 1)
+        case false => t.poke(ref, 0)
+      }
+    }
+  }
+
   /** This alternative to ?== allows a failure message to be specified
     */
   def check(ref: Bits, value: BigInt, msg: String="")(implicit t: InnerTester) {

--- a/src/test/scala/chisel3/iotesters/ChiselPokeSpec.scala
+++ b/src/test/scala/chisel3/iotesters/ChiselPokeSpec.scala
@@ -11,7 +11,7 @@ class MyDut extends Module {
   io.out := io.in + 1.U
 }
 
-class MyDutSpec extends ChiselPokeSpec {
+class ChiselPokeSpecSpec extends ChiselPokeSpec {
   "MyDut" should "properly add" in {
     run(new MyDut) {(t, c) =>
       t.poke(c.io.in, 0x41)
@@ -25,16 +25,16 @@ class MyDutSpec extends ChiselPokeSpec {
   }
 }
 
-class MyImplicitDutSpec extends ChiselImplicitPokeSpec {
+class ChiselImplicitPokeSpecSpec extends ChiselImplicitPokeSpec {
   "MyDut with implicits" should "properly add" in {
     run(new MyDut) {implicit t => c =>
       c.io.in <<= 0x41
       step()
-      assert(c.io.out ?== 0x42)
+      c.io.out ?== 0x42
 
       c.io.in <<= 0x0
       step()
-      assert(c.io.out ?== 0x1)
+      c.io.out ?== 0x1
     }
   }
 }

--- a/src/test/scala/chisel3/iotesters/ChiselPokeSpec.scala
+++ b/src/test/scala/chisel3/iotesters/ChiselPokeSpec.scala
@@ -1,0 +1,40 @@
+// See LICENSE for license details.
+
+import chisel3._
+import chisel3.iotesters.experimental.{ChiselPokeSpec, ChiselImplicitPokeSpec}
+
+class MyDut extends Module {
+  val io = IO(new Bundle {
+    val in = Input(UInt(8.W))
+    val out = Output(UInt(8.W))
+  })
+  io.out := io.in + 1.U
+}
+
+class MyDutSpec extends ChiselPokeSpec {
+  "MyDut" should "properly add" in {
+    run(new MyDut) {(t, c) =>
+      t.poke(c.io.in, 0x41)
+      t.step()
+      t.expect(c.io.out, 0x42)
+
+      t.poke(c.io.in, 0x0)
+      t.step()
+      t.expect(c.io.out, 0x1)
+    }
+  }
+}
+
+class MyImplicitDutSpec extends ChiselImplicitPokeSpec {
+  "MyDut with implicits" should "properly add" in {
+    run(new MyDut) {implicit t => c =>
+      c.io.in <<= 0x41
+      step()
+      assert(c.io.out ?== 0x42)
+
+      c.io.in <<= 0x0
+      step()
+      assert(c.io.out ?== 0x1)
+    }
+  }
+}

--- a/src/test/scala/chisel3/iotesters/ChiselPokeSpec.scala
+++ b/src/test/scala/chisel3/iotesters/ChiselPokeSpec.scala
@@ -1,7 +1,9 @@
 // See LICENSE for license details.
 
 import chisel3._
-import chisel3.iotesters.experimental.{ChiselPokeSpec, ChiselImplicitPokeSpec}
+import chisel3.iotesters.experimental.{PokeTester, ImplicitPokeTester}
+
+import org.scalatest._
 
 class MyDut extends Module {
   val io = IO(new Bundle {
@@ -11,7 +13,7 @@ class MyDut extends Module {
   io.out := io.in + 1.U
 }
 
-class ChiselPokeSpecSpec extends ChiselPokeSpec {
+class PokeTesterSpec extends FlatSpec with PokeTester {
   "MyDut" should "properly add" in {
     run(new MyDut) {(t, c) =>
       t.poke(c.io.in, 0x41)
@@ -25,7 +27,7 @@ class ChiselPokeSpecSpec extends ChiselPokeSpec {
   }
 }
 
-class ChiselImplicitPokeSpecSpec extends ChiselImplicitPokeSpec {
+class ImplicitPokeTesterSpec extends FlatSpec with ImplicitPokeTester {
   "MyDut with implicits" should "properly add" in {
     run(new MyDut) {implicit t => c =>
       c.io.in <<= 0x41


### PR DESCRIPTION
Implementation for #73.

See the included test code for an API example.

Feedback is welcome on the more experimental ChiselImplicitPokeSpec. Especially if there is a way to properly overload triple-equals on FlatSpec.