### PR TITLE
Poking large longs was converting longs to int and losing large values.

### DIFF
--- a/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
@@ -113,6 +113,10 @@ abstract class PeekPokeTester[+T <: Module](
     poke(path, BigInt(value))
   }
 
+  def poke(path: String, value: Long): Unit = {
+    poke(path, BigInt(value))
+  }
+
   def peek(path: String) = backend.peek(path)
 
   def poke(signal: Bits, value: BigInt): Unit = {
@@ -121,6 +125,10 @@ abstract class PeekPokeTester[+T <: Module](
   }
 
   def poke(signal: Bits, value: Int) {
+    poke(signal, BigInt(value))
+  }
+
+  def poke(signal: Bits, value: Long) {
     poke(signal, BigInt(value))
   }
 

--- a/src/test/scala/examples/BigNumbers.scala
+++ b/src/test/scala/examples/BigNumbers.scala
@@ -1,0 +1,39 @@
+// See LICENSE for license details.
+
+package examples
+
+import chisel3._
+import chisel3.iotesters.{PeekPokeTester, TesterOptionsManager}
+import org.scalatest.{FreeSpec, Matchers}
+
+class PassOn extends Module {
+  val io = IO(new Bundle {
+    val in = Input(UInt(64.W))
+    val out = Output(UInt(64.W))
+  })
+  io.out := io.in
+}
+
+class BigNumbersTester(c: PassOn) extends PeekPokeTester(c) {
+  poke (c.io.in, 0x0000000070000000L)
+  expect(c.io.out, 0x0000000070000000L)
+
+  // Test 2:(Test Fails)
+  poke (c.io.in, 0x0000000770000000L)
+  expect (c.io.out, 0x0000000770000000L)
+
+  // Output only takes value of last 32 bits (70000000) and test fails.
+
+  // Test 3:(FIRRTL generates an error)
+  poke (c.io.in, 0x0000000080000000L)
+  expect (c.io.out, 0x0000000080000000L)
+}
+
+class BigNumbersSpec extends FreeSpec with Matchers {
+  "big numbers should work with interpreter backend" in {
+    iotesters.Driver.execute(() => new PassOn, new TesterOptionsManager) { c =>
+      new BigNumbersTester(c)
+    } should be(true)
+
+  }
+}


### PR DESCRIPTION
Fixed by making long specific poke functions
Added test for behavior reported in Chisel3 Issue #425