### PR TITLE
Disambiguating the poking and peeking of aggregates

### DIFF
--- a/src/test/scala/chisel3/iotesters/AggregateOrderingSpec.scala
+++ b/src/test/scala/chisel3/iotesters/AggregateOrderingSpec.scala
@@ -1,0 +1,229 @@
+// See LICENSE for license details.
+
+package chisel3.iotesters
+
+import chisel3._
+import org.scalatest.{FreeSpec, Matchers}
+
+/**
+  * Passes a Vec of elements with one cycle delay
+  * This part of an example of using poke on a Vector input
+  * @param numberOfElements  number of elements to be sorted
+  * @param elementGenerator  generator for kind of elements to be sorted
+  */
+class VecPassThrough(val numberOfElements: Int, elementGenerator: => UInt) extends Module {
+  val io = IO(new Bundle {
+    val inVector = Input(Vec(numberOfElements, elementGenerator))
+    val outVector = Output(Vec(numberOfElements, elementGenerator))
+    val outVectorAsUInt = Output(UInt(inVector.getWidth.W))
+  })
+
+  val regVector = Reg(Vec(numberOfElements, elementGenerator))
+
+  regVector <> io.inVector
+  io.outVector <> regVector
+
+  io.outVectorAsUInt := io.inVector.asUInt()
+}
+
+/**
+  * Passes a Bundle of elements with one cycle delay
+  * This part of an example of using poke on a Vector input
+  */
+class BundlePassThrough extends Module {
+  val io = IO(new Bundle {
+    val inBundle = Input(new PassThroughBundle)
+    val outBundle = Output(new PassThroughBundle)
+    val outBundleAsUInt = Output(UInt(9.W))
+  })
+
+  val regBundle = Reg(new PassThroughBundle)
+
+  regBundle <> io.inBundle
+  io.outBundle <> regBundle
+
+  io.outBundleAsUInt := io.inBundle.asUInt()
+}
+
+class PassThroughBundle extends Bundle {
+  val u1 = UInt(3.W)
+  val u2 = UInt(9.W)
+  val u3 = UInt(27.W)
+}
+
+/**
+  * Demonstrate that calling poke with a IndexedSeq of BigInts
+  * will poke the individual elements of a Vec
+  *
+  * @param c is the device under test
+  */
+class BundlePeekPokeTester(c: BundlePassThrough) extends PeekPokeTester(c) {
+  private val numberOfElements = 3
+
+  private val vectorInputs = Array.tabulate(numberOfElements) { x => BigInt(x + 1) }
+  println(s"scala array to poke into vector    ${vectorInputs.mkString(",")}")
+
+  poke(c.io.inBundle, vectorInputs)
+
+  private val allAtOncePeekedInputs = peek(c.io.inBundle)
+  println(s"input peeked all at once           ${allAtOncePeekedInputs.mkString(",")}")
+
+  private val individualyPeekedInputs = Array(peek(c.io.inBundle.u1), peek(c.io.inBundle.u2), peek(c.io.inBundle.u3))
+  println(s"input peeked individually          ${individualyPeekedInputs.mkString(",")}")
+
+  step(1)
+
+  private val allAtOncePeekedOutputs = peek(c.io.outBundle)
+  println(s"output peeked all at once          ${allAtOncePeekedOutputs.mkString(",")}")
+
+  private val individualyPeekedOutputs = Array(peek(c.io.inBundle.u1), peek(c.io.inBundle.u2), peek(c.io.inBundle.u3))
+  println(s"output peeked individually         ${individualyPeekedOutputs.mkString(",")}")
+}
+
+
+/**
+  * Demonstrate that calling poke with a IndexedSeq of BigInts
+  * will poke the individual elements of a Vec
+  *
+  * @param c is the device under test
+  */
+class VecPeekPokeTester(c: VecPassThrough) extends PeekPokeTester(c) {
+  private val numberOfElements = c.numberOfElements
+
+  private val vectorInputs = Array.tabulate(numberOfElements) { x => BigInt(x) }
+  println(s"scala array to poke into vector    ${vectorInputs.mkString(",")}")
+
+  poke(c.io.inVector, vectorInputs)
+
+  private val allAtOncePeekedInputs = peek(c.io.inVector)
+  println(s"input peeked all at once           ${allAtOncePeekedInputs.mkString(",")}")
+
+  private val individualyPeekedInputs = vectorInputs.indices.map { index => peek(c.io.inVector(index)) }
+  println(s"input peeked individually          ${individualyPeekedInputs.mkString(",")}")
+
+  // @NOTE: The poked array and returned peeked array are opposite
+  assert(vectorInputs.zip(allAtOncePeekedInputs.reverse).forall { case (a, b) => a == b })
+
+  vectorInputs.reverse.zipWithIndex.foreach { case (value, index) =>
+    expect(c.io.inVector(index), value)
+  }
+
+  step(1)
+
+  private val allAtOncePeekedOutputs = vectorInputs.indices.map { index => peek(c.io.outVector(index)) }
+  println(s"output peeked all at once          ${allAtOncePeekedOutputs.mkString(",")}")
+
+  private val individualyPeekedOutputs = vectorInputs.indices.map { index => peek(c.io.inVector(index)) }
+  println(s"output peeked individually         ${individualyPeekedOutputs.mkString(",")}")
+}
+
+/**
+  * Passes a Vec of elements with one cycle delay
+  * This part of an example of using poke on a Vector input
+  */
+class AggregatePassThrough(aggregateGenerator: => Aggregate) extends Module {
+  val io = IO(new Bundle {
+    val inputAggregate = Input(aggregateGenerator)
+    val outputAggregate = Output(aggregateGenerator)
+    val aggregateAsUInt = Output(UInt(aggregateGenerator.getWidth.W))
+    val outputFromUInt = Output(aggregateGenerator)
+  })
+
+  val aggregateRegister = Reg(aggregateGenerator)
+
+  aggregateRegister <> io.inputAggregate
+  io.outputAggregate <> aggregateRegister
+
+  io.aggregateAsUInt := aggregateRegister.asUInt()
+  io.outputFromUInt := aggregateGenerator.fromBits(aggregateRegister.asUInt())
+}
+
+/**
+  * Demonstrate that calling poke with a IndexedSeq of BigInts
+  * will poke the individual elements of a Vec
+  *
+  * @param c is the device under test
+  */
+class AggregateOrderingTester(c: AggregatePassThrough, numberOfElements: Int) extends PeekPokeTester(c) {
+
+  private val startValue = if(numberOfElements < 7) "a" else "0"
+  private val inputArray = Array.tabulate(numberOfElements) { x => BigInt(startValue, 16) + x }
+
+  poke(c.io.inputAggregate, inputArray)
+  private val peekedInput = peek(c.io.inputAggregate)
+
+  step(1)
+
+  private val peekedOutput = peek(c.io.outputAggregate)
+  private val peekedUInt   = peek(c.io.aggregateAsUInt)
+  private val peekedOutputFromUInt = peek(c.io.outputFromUInt)
+
+  println(s"input array that will be poked   " + inputArray.map { bigInt => bigInt.toString(16) }.mkString(""))
+  println(s"peek of the input                " + peekedInput.map { bigInt => bigInt.toString(16) }.mkString(""))
+  println(s"peek of the output               " + peekedOutput.map { bigInt => bigInt.toString(16) }.mkString(""))
+  println(s"peek of the input as UInt        " + peekedUInt.toString(16))
+  println(s"peek of input fromBits of asUInt " + peekedOutputFromUInt.map { bigInt => bigInt.toString(16) }.mkString(""))
+}
+
+class Bundle5 extends Bundle {
+  val u0 = UInt(4.W)
+  val u1 = UInt(4.W)
+  val u2 = UInt(4.W)
+  val u3 = UInt(4.W)
+  val u4 = UInt(4.W)
+}
+
+class BundleOfVecs extends Bundle {
+  val v0 = Vec(2, UInt(4.W))
+  val v1 = Vec(2, UInt(4.W))
+  val v2 = Vec(2, UInt(4.W))
+}
+
+class Bundle2 extends Bundle {
+  val u0 = UInt(4.W)
+  val u1 = UInt(4.W)
+}
+
+class AggregateOrderingSpec extends FreeSpec with Matchers {
+  "the following examples illustrate the poking Vectors and Bundles with an array of BigInt" - {
+    "Poking a 5 element Vec shows" in {
+      iotesters.Driver.execute(() => new AggregatePassThrough(Vec(5, UInt(4.W))), new TesterOptionsManager) { c =>
+        new AggregateOrderingTester(c, 5)
+      } should be(true)
+    }
+    "Poking a 5 element bundle" in {
+      iotesters.Driver.execute(() => new AggregatePassThrough(new Bundle5), new TesterOptionsManager) { c =>
+        new AggregateOrderingTester(c, 5)
+      } should be(true)
+    }
+    "Poking a bundle of 3 vecs of 2 uints each" in {
+      iotesters.Driver.execute(() => new AggregatePassThrough(new BundleOfVecs), new TesterOptionsManager) { c =>
+        new AggregateOrderingTester(c, 6)
+      } should be(true)
+    }
+    "Poking a 3 vec of bundles of 2 uints each" in {
+      iotesters.Driver.execute(() => new AggregatePassThrough(Vec(3, new Bundle2)), new TesterOptionsManager) { c =>
+        new AggregateOrderingTester(c, 6)
+      } should be(true)
+    }
+  }
+
+  """
+    |The following test shows that counter-intuitive order of assignment when poking
+    |a vec with an array of BigInts, currently poking reverse the order, but peeking does not
+    |leading to a big inconsistency""".stripMargin - {
+    "Poking vectors should be same as poking all elements" in {
+      iotesters.Driver.execute(() => new VecPassThrough(10, UInt(16.W)), new TesterOptionsManager) { c =>
+        new VecPeekPokeTester(c)
+      } should be(true)
+    }
+  }
+  "The following illustrates that bundle ordering is " - {
+    "Poking bundles should be same as poking all elements" in {
+      iotesters.Driver.execute(() => new BundlePassThrough, new TesterOptionsManager) { c =>
+        new BundlePeekPokeTester(c)
+      } should be(true)
+    }
+  }
+
+}

--- a/src/test/scala/chisel3/iotesters/VectorPeekPokeSpec.scala
+++ b/src/test/scala/chisel3/iotesters/VectorPeekPokeSpec.scala
@@ -1,0 +1,128 @@
+//// See LICENSE for license details.
+//
+//package chisel3.iotesters
+//
+//import chisel3._
+//import org.scalatest.{FreeSpec, Matchers}
+//
+//
+///**
+//  * Passes a Vec of elements with one cycle delay
+//  * This part of an example of using poke on a Vector input
+//  * @param numberOfElements  number of elements to be sorted
+//  * @param elementGenerator  generator for kind of elements to be sorted
+//  */
+//class VecPassThrough(val numberOfElements: Int, elementGenerator: => UInt) extends Module {
+//  val io = IO(new Bundle {
+//    val inVector = Input(Vec(numberOfElements, elementGenerator))
+//    val outVector = Output(Vec(numberOfElements, elementGenerator))
+//    val outVectorAsUInt = Output(UInt(inVector.getWidth.W))
+//  })
+//
+//  val regVector = Reg(Vec(numberOfElements, elementGenerator))
+//
+//  regVector <> io.inVector
+//  io.outVector <> regVector
+//
+//  io.outVectorAsUInt := io.inVector.asUInt()
+//}
+//
+///**
+//  * Passes a Bundle of elements with one cycle delay
+//  * This part of an example of using poke on a Vector input
+//  */
+//class BundlePassThrough extends Module {
+//  val io = IO(new Bundle {
+//    val inBundle = Input(new PassThroughBundle)
+//    val outBundle = Output(new PassThroughBundle)
+//    val outBundleAsUInt = Output(UInt(9.W))
+//  })
+//
+//  val regBundle = Reg(new PassThroughBundle)
+//
+//  regBundle <> io.inBundle
+//  io.outBundle <> regBundle
+//
+//  io.outBundleAsUInt := io.inBundle.asUInt()
+//}
+//
+//class PassThroughBundle extends Bundle {
+//  val u1 = UInt(3.W)
+//  val u2 = UInt(9.W)
+//  val u3 = UInt(27.W)
+//}
+//
+///**
+//  * Demonstrate that calling poke with a IndexedSeq of BigInts
+//  * will poke the individual elements of a Vec
+//  *
+//  * @param c is the device under test
+//  */
+//class VecPeekPokeTester(c: VecPassThrough) extends PeekPokeTester(c) {
+//  private val numberOfElements = c.numberOfElements
+//
+//  private val vectorInputs = Array.tabulate(numberOfElements) { x => BigInt(x) }
+//  println(s"scala array to poke into vector    ${vectorInputs.mkString(",")}")
+//
+//  poke(c.io.inVector, vectorInputs)
+//
+//  private val allAtOncePeekedInputs = peek(c.io.inVector)
+//  println(s"input peeked all at once           ${allAtOncePeekedInputs.mkString(",")}")
+//
+//  private val individualyPeekedInputs = vectorInputs.indices.map { index => peek(c.io.inVector(index)) }
+//  println(s"input peeked individually          ${individualyPeekedInputs.mkString(",")}")
+//
+//  vectorInputs.zipWithIndex.foreach { case (value, index) =>
+//    expect(c.io.inVector(numberOfElements - (index + 1)), value)
+//  }
+//
+//  step(1)
+//
+//  private val allAtOncePeekedOutputs = vectorInputs.indices.map { index => peek(c.io.outVector(index)) }
+//  println(s"output peeked all at once          ${allAtOncePeekedOutputs.mkString(",")}")
+//
+//  private val individualyPeekedOutputs = vectorInputs.indices.map { index => peek(c.io.inVector(index)) }
+//  println(s"output peeked individually         ${individualyPeekedOutputs.mkString(",")}")
+//}
+//
+///**
+//  * Demonstrate that calling poke with a IndexedSeq of BigInts
+//  * will poke the individual elements of a Vec
+//  *
+//  * @param c is the device under test
+//  */
+//class BundlePeekPokeTester(c: BundlePassThrough) extends PeekPokeTester(c) {
+//  private val numberOfElements = 3
+//
+//  private val vectorInputs = Array.tabulate(numberOfElements) { x => BigInt(x + 1) }
+//  println(s"scala array to poke into vector    ${vectorInputs.mkString(",")}")
+//
+//  poke(c.io.inBundle, vectorInputs)
+//
+//  private val allAtOncePeekedInputs = peek(c.io.inBundle)
+//  println(s"input peeked all at once           ${allAtOncePeekedInputs.mkString(",")}")
+//
+//  private val individualyPeekedInputs = Array(peek(c.io.inBundle.u1), peek(c.io.inBundle.u2), peek(c.io.inBundle.u3))
+//  println(s"input peeked individually          ${individualyPeekedInputs.mkString(",")}")
+//
+//  step(1)
+//
+//  private val allAtOncePeekedOutputs = peek(c.io.outBundle)
+//  println(s"output peeked all at once          ${allAtOncePeekedOutputs.mkString(",")}")
+//
+//  private val individualyPeekedOutputs = Array(peek(c.io.inBundle.u1), peek(c.io.inBundle.u2), peek(c.io.inBundle.u3))
+//  println(s"output peeked individually         ${individualyPeekedOutputs.mkString(",")}")
+//}
+//
+//class VectorPeekPokeSpec extends FreeSpec with Matchers {
+//  "Poking vectors should be same as poking all elements" in {
+//    iotesters.Driver.execute(() => new VecPassThrough(10, UInt(16.W)), new TesterOptionsManager) { c =>
+//      new VecPeekPokeTester(c)
+//    } should be(true)
+//  }
+//  "Poking bundles should be same as poking all elements" in {
+//    iotesters.Driver.execute(() => new BundlePassThrough, new TesterOptionsManager) { c =>
+//      new BundlePeekPokeTester(c)
+//    } should be(true)
+//  }
+//}


### PR DESCRIPTION
Added at test AggregateOrderingSpec that shows some of the quirks involved.
Nothing changed in API, though the stuff presents some reasons to do so