### PR TITLE
Use IrrevocableIO for sink in AdvTester, reflecting assumptions

### DIFF
--- a/src/main/scala/chisel3/iotesters/AdvTester.scala
+++ b/src/main/scala/chisel3/iotesters/AdvTester.scala
@@ -98,7 +98,7 @@ abstract class AdvTester[+T <: Module](dut: T,
     expr
   }
 
-  class DecoupledSink[T <: Data, R]( socket: DecoupledIO[T], cvt: T=>R, 
+  class IrrevocableSink[T <: Data, R]( socket: IrrevocableIO[T], cvt: T=>R, 
     max_count: Option[Int] = None ) extends Processable
   {
     val outputs = new scala.collection.mutable.Queue[R]()
@@ -119,9 +119,9 @@ abstract class AdvTester[+T <: Module](dut: T,
     wire_poke(socket.ready, 1)
     preprocessors += this
   }
-  object DecoupledSink {
-    def apply[T<:Bits](socket: DecoupledIO[T]) =
-      new DecoupledSink(socket, (socket_bits: T) => peek(socket_bits))
+  object IrrevocableSink {
+    def apply[T<:Bits](socket: IrrevocableIO[T]) =
+      new IrrevocableSink(socket, (socket_bits: T) => peek(socket_bits))
   }
 
   class ValidSink[T <: Data, R]( socket: ValidIO[T], cvt: T=>R ) extends Processable

--- a/src/test/scala/examples/DecoupledAdvTester.scala
+++ b/src/test/scala/examples/DecoupledAdvTester.scala
@@ -52,7 +52,7 @@ class SmallOdds5(filter_width: Int) extends Module {
 class SmallOdds5Tester(dut: SmallOdds5) extends AdvTester(dut) {
   val max_tick_count = 8
   val testerInputDriver = DecoupledSource(dut.io.in)
-  val testerOutputHandler = DecoupledSink(dut.io.out)
+  val testerOutputHandler = IrrevocableSink(dut.io.out)
   for (i <- 0 to 300) {
     val num = rnd.nextInt(20)
     testerInputDriver.inputs.enqueue(num)


### PR DESCRIPTION
This depends on ucb-bar/chisel3#436 to change `IrrevocableIO` to a subtype of `DecoupledIO` and to make `EnqIO` (for the output of `Queue`) return an `IrrevocableIO`.