### PR TITLE
API change: Change  peek and expect to get negatives when applied to SInt

### DIFF
--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -4,9 +4,11 @@ package chisel3.iotesters
 import chisel3.internal.InstanceId
 
 import scala.util.Random
-import java.io.{File, Writer, FileWriter, PrintStream, IOException}
+import java.io.{File, FileWriter, IOException, PrintStream, Writer}
 import java.nio.file.{FileAlreadyExistsException, Files, Paths}
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+
+import chisel3.SInt
 
 /**
   * Copies the necessary header files used for verilator compilation to the specified destination folder
@@ -331,13 +333,30 @@ private[iotesters] class VerilatorBackend(dut: Chisel.Module,
           (implicit logger: PrintStream, verbose: Boolean, base: Int): BigInt = {
     val idx = off map (x => s"[$x]") getOrElse ""
     val path = s"${signal.parentPathName}.${validName(signal.instanceName)}$idx"
-    peek(path)
+    signal match {
+      case sInt: SInt =>
+        val bigInt = peek(path)
+        if(bigInt.bitLength >= sInt.getWidth) {
+          - ((BigInt(1) << sInt.getWidth) - bigInt)
+        }
+        else {
+          bigInt
+        }
+      case _ =>
+        peek(path)
+    }
   }
 
   def expect(signal: InstanceId, expected: BigInt, msg: => String)
             (implicit logger: PrintStream, verbose: Boolean, base: Int): Boolean = {
     val path = s"${signal.parentPathName}.${validName(signal.instanceName)}"
-    expect(path, expected, msg)
+
+    val got = peek(signal, None)
+    val good = got == expected
+    if (verbose) logger println (
+      s"""${msg}  EXPECT ${path} -> ${bigIntToStr(got, base)} == """ +
+        s"""${bigIntToStr(expected, base)} ${if (good) "PASS" else "FAIL"}""")
+    good
   }
 
   def expect(signal: InstanceId, expected: Int, msg: => String)

--- a/src/test/scala/examples/Adder.scala
+++ b/src/test/scala/examples/Adder.scala
@@ -3,7 +3,8 @@
 package examples
 
 import chisel3._
-import chisel3.iotesters.{SteppedHWIOTester, ChiselFlatSpec, Exerciser}
+import chisel3.iotesters.{ChiselFlatSpec, Exerciser, PeekPokeTester, SteppedHWIOTester}
+import org.scalatest.{FreeSpec, Matchers}
 
 class Adder(val w: Int) extends Module {
   val io = IO(new Bundle {
@@ -76,3 +77,84 @@ class AdderTester extends ChiselFlatSpec {
     assertTesterPasses { new AdderTests }
   }
 }
+
+class SignedAdder(val w: Int) extends Module {
+  val io = IO(new Bundle {
+    val in0 = Input(SInt(w.W))
+    val in1 = Input(SInt(w.W))
+    val out = Output(SInt(w.W))
+  })
+  // printf("in0 %d in1 %d result %d\n", io.in0, io.in1, io.out)
+  io.out := io.in0 + io.in1
+}
+
+class SignedAdderTester(c: SignedAdder) extends PeekPokeTester(c) {
+  for {
+    i <- -10 to 10
+    j <- -10 to 10
+  } {
+    poke(c.io.in0, i)
+    poke(c.io.in1, j)
+    step(1)
+    println(s"signed adder $i + $j got ${peek(c.io.out)} should be ${i+j}")
+    expect(c.io.out, i + j)
+    step(1)
+  }
+}
+
+class SignedAdderSpec extends FreeSpec with Matchers {
+  "tester should returned signed values with interpreter" in {
+    iotesters.Driver.execute(Array("--backend-name", "firrtl"), () => new SignedAdder(16)) { c =>
+      new SignedAdderTester(c)
+    } should be (true)
+  }
+
+  "tester should returned signed values with verilator" in {
+    iotesters.Driver.execute(Array("--backend-name", "verilator"), () => new SignedAdder(16)) { c =>
+      new SignedAdderTester(c)
+    } should be (true)
+  }
+}
+
+class FixedPointAdder(val w: Int) extends Module {
+  val io = IO(new Bundle {
+    val in0 = Input(FixedPoint(width = 16, binaryPoint = 2))
+    val in1 = Input(FixedPoint(width = 16, binaryPoint = 2))
+    val out = Output(FixedPoint(width = 16, binaryPoint = 2))
+  })
+  // printf("in0 %d in1 %d result %d\n", io.in0, io.in1, io.out)
+  io.out := io.in0 + io.in1
+}
+
+class FixedPointAdderTester(c: FixedPointAdder) extends PeekPokeTester(c) {
+  for {
+//    i <- -10 to 10
+//    j <- -10 to 10
+    i <- -10 to -9
+    j <- -10 to -8
+  } {
+    poke(c.io.in0, i)
+    poke(c.io.in1, j)
+    step(1)
+    println(s"signed adder $i + $j got ${peek(c.io.out)} should be ${i+j}")
+    expect(c.io.out, i + j)
+    step(1)
+  }
+
+}
+
+class FixedPointAdderSpec extends FreeSpec with Matchers {
+  "tester should returned signed values with interpreter" in {
+    iotesters.Driver.execute(Array("--backend-name", "firrtl"), () => new FixedPointAdder(16)) { c =>
+      new FixedPointAdderTester(c)
+    } should be (true)
+  }
+
+  //TODO: make this work
+  "tester should returned signed values" ignore {
+    iotesters.Driver.execute(Array("--backend-name", "verilator"), () => new FixedPointAdder(16)) { c =>
+      new FixedPointAdderTester(c)
+    } should be (true)
+  }
+}
+


### PR DESCRIPTION
This seems like an obvious fix, but it does change the API.  Although currently the API behavior is different between the interpreter and verilator backend

Change PeekPokeTester #peek and #expect to return signed BigInt if the signalId they are given is an SInt
Add a signed adder test to confirm this works
This needs to be further built out with fixed point