### PR TITLE
make peek print bigint with correct sign

### DIFF
--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -333,16 +333,20 @@ private[iotesters] class VerilatorBackend(dut: Chisel.Module,
           (implicit logger: PrintStream, verbose: Boolean, base: Int): BigInt = {
     val idx = off map (x => s"[$x]") getOrElse ""
     val path = s"${signal.parentPathName}.${validName(signal.instanceName)}$idx"
-    val bigIntU = peek(path)
+    val bigIntU = simApiInterface.peek(path) getOrElse BigInt(rnd.nextInt)
+  
     def signConvert(bigInt: BigInt, width: Int): BigInt = {
       if(bigInt.bitLength >= width) - ((BigInt(1) << width) - bigInt)
       else bigInt
     }
-    signal match {
+
+    val result = signal match {
       case s: SInt => signConvert(bigIntU, s.getWidth)
       case f: FixedPoint => signConvert(bigIntU, f.getWidth)
       case _ => bigIntU
     }
+    if (verbose) logger println s"  PEEK ${path} -> ${bigIntToStr(result, base)}"
+    result
   }
 
   def expect(signal: InstanceId, expected: BigInt, msg: => String)


### PR DESCRIPTION
Basically, after previous changes, Peek would return the correct (signed) BigInt, but, in verbose mode, it would print the unsigned version of the returned value. Theoretically, that's ok too, but it's inconsistent with what Poke (and otherwise Peek.litValue) would give you... This only addresses peek on InstanceId (and not on peek Path:String -- since you lose sign info there). This fix was only applied to VerilatorBackend. It'd probably make sense to double check consistency for Interpretter/VCS backend, but that's not something I'm concerned with atm. @chick can you stare at this and merge if you're OK? This should actually be a quick fix ;)