### PR TITLE
Pass through annos, support for black box verilog implementations

### DIFF
--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -8,8 +8,11 @@ import java.io.{File, FileWriter, IOException, PrintStream, Writer}
 import java.nio.file.{FileAlreadyExistsException, Files, Paths}
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
-import chisel3.SInt
+import chisel3.{ChiselExecutionFailure, ChiselExecutionSucccess, SInt}
 import chisel3.experimental.FixedPoint
+import firrtl.annotations.CircuitName
+import firrtl.transforms.{BlackBoxSourceHelper, BlackBoxTargetDir}
+import firrtl.{AnnotationMap, FirrtlExecutionFailure, FirrtlExecutionSuccess}
 
 /**
   * Copies the necessary header files used for verilator compilation to the specified destination folder
@@ -265,12 +268,71 @@ class VerilatorCppHarnessCompiler(dut: Chisel.Module,
   def transforms = Seq(
     new firrtl.ChirrtlToHighFirrtl,
     new firrtl.IRToWorkingIR,
-    new firrtl.ResolveAndCheck
+    new firrtl.ResolveAndCheck,
+    new firrtl.transforms.BlackBoxSourceHelper
   )
 }
 
 private[iotesters] object setupVerilatorBackend {
   def apply[T <: chisel3.Module](dutGen: () => T, optionsManager: TesterOptionsManager): (T, Backend) = {
+    import firrtl.{CircuitState, ChirrtlForm}
+
+    optionsManager.makeTargetDir()
+
+    optionsManager.chiselOptions = optionsManager.chiselOptions.copy(
+      runFirrtlCompiler = false
+    )
+    val dir = new File(optionsManager.targetDirName)
+
+    // Generate CHIRRTL
+    chisel3.Driver.execute(optionsManager, dutGen) match {
+      case ChiselExecutionSucccess(Some(circuit), emitted, _) =>
+
+        //      val circuit = chisel3.Driver.elaborate(dutGen)
+        //      val chirrtl = firrtl.Parser.parse(chisel3.Driver.emit(circuit))
+
+        val chirrtl = firrtl.Parser.parse(emitted)
+        val dut = getTopModule(circuit).asInstanceOf[T]
+        val nodes = getChiselNodes(circuit)
+
+        val annotationMap = firrtl.AnnotationMap(optionsManager.firrtlOptions.annotations ++ List(
+          firrtl.passes.memlib.InferReadWriteAnnotation(circuit.name),
+          firrtl.annotations.Annotation(
+            CircuitName(circuit.name),
+            classOf[BlackBoxSourceHelper],
+            BlackBoxTargetDir(optionsManager.targetDirName).serialize
+          )
+        ))
+
+        // Generate Verilog
+        val verilogFile = new File(dir, s"${circuit.name}.v")
+        val verilogWriter = new FileWriter(verilogFile)
+
+        (new firrtl.VerilogCompiler).compile(
+          CircuitState(chirrtl, ChirrtlForm, Some(annotationMap)),
+          verilogWriter,
+          List(new firrtl.passes.memlib.InferReadWrite))
+        verilogWriter.close()
+
+        val cppHarnessFileName = s"${circuit.name}-harness.cpp"
+        val cppHarnessFile = new File(dir, cppHarnessFileName)
+        val cppHarnessWriter = new FileWriter(cppHarnessFile)
+        val vcdFile = new File(dir, s"${circuit.name}.vcd")
+        val harnessCompiler = new VerilatorCppHarnessCompiler(dut, nodes, vcdFile.toString)
+        copyVerilatorHeaderFiles(dir.toString)
+        harnessCompiler.compile(
+          CircuitState(chirrtl, ChirrtlForm, Some(annotationMap)), // TODO do we actually need this annotation?
+          cppHarnessWriter)
+        cppHarnessWriter.close()
+        assert(chisel3.Driver.verilogToCpp(circuit.name, circuit.name, dir, Seq(), new File(cppHarnessFileName)).! == 0)
+        assert(chisel3.Driver.cppToExe(circuit.name, dir).! == 0)
+
+        (dut, new VerilatorBackend(dut, Seq((new File(dir, s"V${circuit.name}")).toString)))
+      case ChiselExecutionFailure(message) =>
+        throw new Exception(message)
+    }
+  }
+  def oldApply[T <: chisel3.Module](dutGen: () => T, optionsManager: TesterOptionsManager): (T, Backend) = {
     import firrtl.{CircuitState, ChirrtlForm}
 
     optionsManager.makeTargetDir()

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -268,8 +268,7 @@ class VerilatorCppHarnessCompiler(dut: Chisel.Module,
   def transforms = Seq(
     new firrtl.ChirrtlToHighFirrtl,
     new firrtl.IRToWorkingIR,
-    new firrtl.ResolveAndCheck,
-    new firrtl.transforms.BlackBoxSourceHelper
+    new firrtl.ResolveAndCheck
   )
 }
 

--- a/src/test/resources/AddTwoAddThree.v
+++ b/src/test/resources/AddTwoAddThree.v
@@ -1,0 +1,17 @@
+module BBAddTwo(
+    input  [15:0] in,
+    output reg [15:0] out
+);
+  always @* begin
+  out <= in + 2;
+  end
+endmodule
+
+module BBAddThree(
+    input  [15:0] in,
+    output reg [15:0] out
+);
+  always @* begin
+  out <= in + 3;
+  end
+endmodule

--- a/src/test/scala/chisel3/iotesters/BlackBoxVerilogDeliverySpec.scala
+++ b/src/test/scala/chisel3/iotesters/BlackBoxVerilogDeliverySpec.scala
@@ -76,9 +76,17 @@ class BlackBoxVerilogDeliverySpec extends FreeSpec with Matchers {
     } should be (true)
   }
 
-  "blackbox verilog implementation should end up accessible to vcs" in {
-    iotesters.Driver.execute(Array("--backend-name", "vcs"), () => new UsesBBAddOne) { c =>
-      new UsesBBAddOneTester(c)
-    } should be (true)
-  }
+  //TODO: The following fails or succeeds depending on vcs in users path, figure out how to test
+//  "blackbox verilog implementation should end up accessible to vcs" in {
+//    val manager = new TesterOptionsManager {
+//      testerOptions = testerOptions.copy(backendName = "vcs")
+//    }
+//    intercept[AssertionError] {
+//      iotesters.Driver.execute(() => new UsesBBAddOne, manager) { c =>
+//        new UsesBBAddOneTester(c)
+//      } should be(true)
+//    }
+//    new java.io.File(
+//        manager.targetDirName, firrtl.transforms.BlackBoxSourceHelper.FileListName).exists() should be (true)
+//  }
 }

--- a/src/test/scala/chisel3/iotesters/BlackBoxVerilogDeliverySpec.scala
+++ b/src/test/scala/chisel3/iotesters/BlackBoxVerilogDeliverySpec.scala
@@ -1,0 +1,84 @@
+// See LICENSE for license details.
+
+package chisel3.iotesters
+
+import chisel3._
+import chisel3.util.{HasBlackBoxInline, HasBlackBoxResource}
+import org.scalatest.{FreeSpec, Matchers}
+
+class BBAddOne extends HasBlackBoxInline {
+  val io = IO(new Bundle {
+    val in = Input(UInt(16.W))
+    val out = Output(UInt(16.W))
+  })
+  setInline("BBAddOne.v",
+  """
+    |module BBAddOne(
+    |    input  [15:0] in,
+    |    output reg [15:0] out
+    |);
+    |  always @* begin
+    |  out <= in + 1;
+    |  end
+    |endmodule
+  """.stripMargin)
+}
+
+class BBAddTwo extends HasBlackBoxResource {
+  val io = IO(new Bundle {
+    val in = Input(UInt(16.W))
+    val out = Output(UInt(16.W))
+  })
+  setResource("/AddTwoAddThree.v")
+}
+
+class BBAddThree extends HasBlackBoxResource {
+  val io = IO(new Bundle {
+    val in = Input(UInt(16.W))
+    val out = Output(UInt(16.W))
+  })
+  setResource("/AddTwoAddThree.v")
+}
+
+class UsesBBAddOne extends Module {
+  val io = IO(new Bundle {
+    val in = Input(UInt(16.W))
+    val out1 = Output(UInt(16.W))
+    val out2 = Output(UInt(16.W))
+    val out3 = Output(UInt(16.W))
+  })
+  val bbAddOne = Module(new BBAddOne)
+  bbAddOne.io.in := io.in
+  io.out1 := bbAddOne.io.out
+
+  val bbAddTwo = Module(new BBAddTwo)
+  bbAddTwo.io.in := io.in
+  io.out2 := bbAddTwo.io.out
+
+  val bbAddThree = Module(new BBAddThree)
+  bbAddThree.io.in := io.in
+  io.out3 := bbAddThree.io.out
+}
+
+class UsesBBAddOneTester(c: UsesBBAddOne) extends PeekPokeTester(c) {
+  poke(c.io.in, 1)
+  step(1)
+  expect(c.io.out1, 2)
+  expect(c.io.out2, 3)
+  expect(c.io.out3, 4)
+  step(1)
+}
+
+class BlackBoxVerilogDeliverySpec extends FreeSpec with Matchers {
+  "blackbox verilog implementation should end up accessible to verilator" in {
+    iotesters.Driver.execute(Array("--backend-name", "verilator"), () => new UsesBBAddOne) { c =>
+      new UsesBBAddOneTester(c)
+    } should be (true)
+  }
+
+  "blackbox verilog implementation should end up accessible to vcs" in {
+    iotesters.Driver.execute(Array("--backend-name", "vcs"), () => new UsesBBAddOne) { c =>
+      new UsesBBAddOneTester(c)
+    } should be (true)
+  }
+}


### PR DESCRIPTION

Fixes a problem where the Driver execution harness was not passing down annotations from higher level libraries.  Add hooks to call verilator and vcs in a way to know about verilog files placed in the target directory