### PR TITLE
--test-command was broken

### DIFF
--- a/src/main/scala/chisel3/iotesters/TesterOptions.scala
+++ b/src/main/scala/chisel3/iotesters/TesterOptions.scala
@@ -19,7 +19,7 @@ case class TesterOptions(
                           isVerbose:       Boolean = false,
                           displayBase:     Int     = 10,
                           testerSeed:      Long    = System.currentTimeMillis,
-                          testCmd:         mutable.ArrayBuffer[String]= mutable.ArrayBuffer[String](),
+                          testCmd:         Seq[String] = Seq.empty,
                           backendName:     String  = "firrtl",
                           logFileName:     String  = "",
                           waveform:        Option[File] = None) extends ComposableOptions
@@ -65,10 +65,10 @@ trait HasTesterOptions {
     .foreach { x => testerOptions = testerOptions.copy(displayBase = x) }
     .text(s"provides a seed for random number generator, default is ${testerOptions.displayBase}")
 
-  parser.opt[Seq[String]]("test-command")
+  parser.opt[String]("test-command")
     .abbr("ttc")
-    .foreach { x => testerOptions = testerOptions.copy(testCmd = testerOptions.testCmd ++ x) }
-    .text("run this as test command")
+    .foreach { x => testerOptions = testerOptions.copy(testCmd = x.split("""\s""")) }
+    .text("Change the command run as the backend. Quote this if it contains spaces")
 
   parser.opt[String]("log-file-name")
     .abbr("tlfn")

--- a/src/main/scala/chisel3/iotesters/VCSBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VCSBackend.scala
@@ -146,7 +146,7 @@ private[iotesters] object setupVCSBackend {
     val command = if(optionsManager.testerOptions.testCmd.nonEmpty) {
       optionsManager.testerOptions.testCmd
     } else {
-      Seq((new File(dir, s"V${circuit.name}")).toString)
+      Seq(new File(dir, circuit.name).toString)
     }
 
     (dut, new VCSBackend(dut, command))

--- a/src/main/scala/chisel3/iotesters/VCSBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VCSBackend.scala
@@ -143,7 +143,13 @@ private[iotesters] object setupVCSBackend {
     genVCSVerilogHarness(dut, new FileWriter(vcsHarnessFile), vpdFile.toString)
     assert(verilogToVCS(circuit.name, dir, new File(vcsHarnessFileName)).! == 0)
 
-    (dut, new VCSBackend(dut, Seq((new File(dir, circuit.name)).toString)))
+    val command = if(optionsManager.testerOptions.testCmd.nonEmpty) {
+      optionsManager.testerOptions.testCmd
+    } else {
+      Seq((new File(dir, s"V${circuit.name}")).toString)
+    }
+
+    (dut, new VCSBackend(dut, command))
   }
 }
 

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -8,8 +8,11 @@ import java.io.{File, FileWriter, IOException, PrintStream, Writer}
 import java.nio.file.{FileAlreadyExistsException, Files, Paths}
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
-import chisel3.SInt
+import chisel3.{ChiselExecutionFailure, ChiselExecutionSucccess, SInt}
 import chisel3.experimental.FixedPoint
+import firrtl.annotations.{Annotation, CircuitName}
+import firrtl.transforms.{BlackBoxResource, BlackBoxInline, BlackBoxSource, BlackBoxSourceHelper, BlackBoxTargetDir}
+import firrtl.{AnnotationMap, FileUtils, FirrtlExecutionFailure, FirrtlExecutionSuccess}
 
 /**
   * Copies the necessary header files used for verilator compilation to the specified destination folder
@@ -274,41 +277,74 @@ private[iotesters] object setupVerilatorBackend {
     import firrtl.{CircuitState, ChirrtlForm}
 
     optionsManager.makeTargetDir()
+
+    optionsManager.chiselOptions = optionsManager.chiselOptions.copy(
+      runFirrtlCompiler = false
+    )
     val dir = new File(optionsManager.targetDirName)
 
     // Generate CHIRRTL
-    val circuit = chisel3.Driver.elaborate(dutGen)
-    val chirrtl = firrtl.Parser.parse(chisel3.Driver.emit(circuit))
-    val dut = getTopModule(circuit).asInstanceOf[T]
-    val nodes = getChiselNodes(circuit)
+    chisel3.Driver.execute(optionsManager, dutGen) match {
+      case ChiselExecutionSucccess(Some(circuit), emitted, _) =>
 
-    // Generate Verilog
-    val verilogFile = new File(dir, s"${circuit.name}.v")
-    val verilogWriter = new FileWriter(verilogFile)
+        //      val circuit = chisel3.Driver.elaborate(dutGen)
+        //      val chirrtl = firrtl.Parser.parse(chisel3.Driver.emit(circuit))
 
-    // TODO why do we need to infer readwrite?
-    val annotations = firrtl.AnnotationMap(Seq(
-      firrtl.passes.memlib.InferReadWriteAnnotation(circuit.name)))
-    (new firrtl.VerilogCompiler).compile(
-      CircuitState(chirrtl, ChirrtlForm, Some(annotations)),
-      verilogWriter,
-      List(new firrtl.passes.memlib.InferReadWrite))
-    verilogWriter.close()
+        val chirrtl = firrtl.Parser.parse(emitted)
+        val dut = getTopModule(circuit).asInstanceOf[T]
+        val nodes = getChiselNodes(circuit)
 
-    val cppHarnessFileName = s"${circuit.name}-harness.cpp"
-    val cppHarnessFile = new File(dir, cppHarnessFileName)
-    val cppHarnessWriter = new FileWriter(cppHarnessFile)
-    val vcdFile = new File(dir, s"${circuit.name}.vcd")
-    val harnessCompiler = new VerilatorCppHarnessCompiler(dut, nodes, vcdFile.toString)
-    copyVerilatorHeaderFiles(dir.toString)
-    harnessCompiler.compile(
-      CircuitState(chirrtl, ChirrtlForm, Some(annotations)), // TODO do we actually need this annotation?
-      cppHarnessWriter)
-    cppHarnessWriter.close()
-    assert(chisel3.Driver.verilogToCpp(circuit.name, circuit.name, dir, Seq(), new File(cppHarnessFileName)).! == 0)
-    assert(chisel3.Driver.cppToExe(circuit.name, dir).! == 0)
+        val annotationMap = firrtl.AnnotationMap(optionsManager.firrtlOptions.annotations ++ List(
+          firrtl.passes.memlib.InferReadWriteAnnotation(circuit.name),
+          firrtl.annotations.Annotation(
+            CircuitName(circuit.name),
+            classOf[BlackBoxSourceHelper],
+            BlackBoxTargetDir(optionsManager.targetDirName).serialize
+          )
+        ))
 
-    (dut, new VerilatorBackend(dut, Seq((new File(dir, s"V${circuit.name}")).toString)))
+        // Generate Verilog
+        val verilogFile = new File(dir, s"${circuit.name}.v")
+        val verilogWriter = new FileWriter(verilogFile)
+
+        (new firrtl.VerilogCompiler).compile(
+          CircuitState(chirrtl, ChirrtlForm, Some(annotationMap)),
+          verilogWriter,
+          List(new firrtl.passes.memlib.InferReadWrite))
+        verilogWriter.close()
+
+        val cppHarnessFileName = s"${circuit.name}-harness.cpp"
+        val cppHarnessFile = new File(dir, cppHarnessFileName)
+        val cppHarnessWriter = new FileWriter(cppHarnessFile)
+        val vcdFile = new File(dir, s"${circuit.name}.vcd")
+        val harnessCompiler = new VerilatorCppHarnessCompiler(dut, nodes, vcdFile.toString)
+        copyVerilatorHeaderFiles(dir.toString)
+        harnessCompiler.compile(
+          CircuitState(chirrtl, ChirrtlForm, Some(annotationMap)), // TODO do we actually need this annotation?
+          cppHarnessWriter)
+        cppHarnessWriter.close()
+
+        assert(
+          chisel3.Driver.verilogToCpp(
+            circuit.name,
+            circuit.name,
+            dir,
+            vSources = Seq(),
+            new File(cppHarnessFileName)
+          ).! == 0
+        )
+        assert(chisel3.Driver.cppToExe(circuit.name, dir).! == 0)
+
+        val command = if(optionsManager.testerOptions.testCmd.nonEmpty) {
+          optionsManager.testerOptions.testCmd
+        } else {
+          Seq((new File(dir, s"V${circuit.name}")).toString)
+        }
+
+        (dut, new VerilatorBackend(dut, command))
+      case ChiselExecutionFailure(message) =>
+        throw new Exception(message)
+    }
   }
 }
 

--- a/src/test/scala/chisel3/iotesters/DriverSpec.scala
+++ b/src/test/scala/chisel3/iotesters/DriverSpec.scala
@@ -2,8 +2,9 @@
 
 package chisel3.iotesters
 
-import org.scalatest.{Matchers, FreeSpec}
+import java.io.File
 
+import org.scalatest.{FreeSpec, Matchers}
 import chisel3._
 
 class DriverTest extends Module {
@@ -20,9 +21,27 @@ class DriverTestTester(c: DriverTest) extends PeekPokeTester(c) {
 }
 
 class DriverSpec extends FreeSpec with Matchers {
+  /**
+    * recursively delete all directories in a relative path
+    * DO NOT DELETE absolute paths
+    *
+    * @param file: a directory hierarchy to delete
+    */
+  def deleteDirectoryHierarchy(file: File): Unit = {
+    if(file.getAbsolutePath.split("/").last.isEmpty || file.getAbsolutePath == "/") {
+      // don't delete absolute path
+    }
+    else {
+      if(file.isDirectory) {
+        file.listFiles().foreach( f => deleteDirectoryHierarchy(f) )
+      }
+      file.delete()
+    }
+  }
+
   "tester driver should support a wide range of downstream toolchain options" - {
 
-    "default roptions should not fail" in {
+    "default options should not fail" in {
       chisel3.iotesters.Driver.execute(
         Array.empty[String],
         () => new DriverTest) { c =>
@@ -33,6 +52,56 @@ class DriverSpec extends FreeSpec with Matchers {
       chisel3.iotesters.Driver.execute(
         Array("--i-am-a-bad-argument"),
         () => new DriverTest) { c => new DriverTestTester(c)} should be (false)
+    }
+
+    "this is the way to override the target directory" - {
+      "specifying targetDir alone will create a subdir" in {
+        val driverTestDir = "driver_spec_test_1"
+        chisel3.iotesters.Driver.execute(
+          Array("--target-dir", driverTestDir),
+          () => new DriverTest
+        ) { c =>
+          new DriverTestTester(c)
+        } should be (true)
+        val dir = new File(driverTestDir)
+        dir.exists() should be (true)
+        //
+        dir.listFiles().exists { f =>
+          f.getAbsolutePath.split("/").last.startsWith("chisel3.iotesters.DriverSpec") &&
+            f.isDirectory
+        }  should be (true)
+        deleteDirectoryHierarchy(new File(driverTestDir))
+      }
+
+      "specifying targetDir and topName will avoid the subdir" in {
+        val driverTestDir = "driver_spec_test_2"
+        chisel3.iotesters.Driver.execute(
+          Array("--target-dir", driverTestDir, "--top-name", "DriverTest"),
+          () => new DriverTest
+        ) { c =>
+          new DriverTestTester(c)
+        } should be (true)
+        val dir = new File(driverTestDir)
+        dir.exists() should be (true)
+        //
+        dir.listFiles().exists { f =>
+          f.getAbsolutePath.split("/").last == "DriverTest.v"
+        } should be (true)
+        deleteDirectoryHierarchy(new File(driverTestDir))
+      }
+    }
+
+    "example of setting test command" in {
+      val manager = new TesterOptionsManager {
+        testerOptions = testerOptions.copy(backendName = "verilator", testCmd = Seq("foo2/VDriverTest"))
+        commonOptions = commonOptions.copy(targetDirName = "foo2", topName = "DriverTest")
+        interpreterOptions = interpreterOptions.copy(setVerbose = false, writeVCD = true)
+      }
+      iotesters.Driver.execute(() => new DriverTest, manager) { c =>
+        new DriverTestTester(c)
+      } should be (true)
+
+      deleteDirectoryHierarchy(new File("foo2"))
     }
   }
 }


### PR DESCRIPTION
fix --test-command so that it is used in verilator and vcs backends
add test to DriverSpec to illustrate it's use.
added two other tests to DriverSpec to illustrate overriding directories