### PR TITLE
fixed sign out of verilator for when bitLength isn't as expected

### DIFF
--- a/src/main/scala/chisel3/iotesters/VCSBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VCSBackend.scala
@@ -7,7 +7,7 @@ import java.io.{File, FileWriter, IOException, PrintStream, Writer}
 import java.nio.file.{FileAlreadyExistsException, Files, Paths}
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
-import chisel3.{ChiselExecutionFailure, ChiselExecutionSucccess}
+import chisel3.{ChiselExecutionFailure, ChiselExecutionSuccess}
 import firrtl.annotations.CircuitName
 import firrtl.transforms.{BlackBoxSourceHelper, BlackBoxTargetDir}
 
@@ -126,7 +126,7 @@ private[iotesters] object setupVCSBackend {
 
     // Generate CHIRRTL
     chisel3.Driver.execute(optionsManager, dutGen) match {
-      case ChiselExecutionSucccess(Some(circuit), emitted, _) =>
+      case ChiselExecutionSuccess(Some(circuit), emitted, _) =>
 
         val chirrtl = firrtl.Parser.parse(emitted)
         val dut = getTopModule(circuit).asInstanceOf[T]

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -8,7 +8,7 @@ import java.io.{File, FileWriter, IOException, PrintStream, Writer}
 import java.nio.file.{FileAlreadyExistsException, Files, Paths}
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
-import chisel3.{ChiselExecutionFailure, ChiselExecutionSucccess, SInt}
+import chisel3.{ChiselExecutionFailure, ChiselExecutionSuccess, SInt}
 import chisel3.experimental.FixedPoint
 import firrtl.annotations.{Annotation, CircuitName}
 import firrtl.transforms.{BlackBoxResource, BlackBoxInline, BlackBoxSource, BlackBoxSourceHelper, BlackBoxTargetDir}
@@ -285,7 +285,7 @@ private[iotesters] object setupVerilatorBackend {
 
     // Generate CHIRRTL
     chisel3.Driver.execute(optionsManager, dutGen) match {
-      case ChiselExecutionSucccess(Some(circuit), emitted, _) =>
+      case ChiselExecutionSuccess(Some(circuit), emitted, _) =>
 
         //      val circuit = chisel3.Driver.elaborate(dutGen)
         //      val chirrtl = firrtl.Parser.parse(chisel3.Driver.emit(circuit))

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -337,12 +337,17 @@ private[iotesters] class VerilatorBackend(dut: Chisel.Module,
     val bigIntU = simApiInterface.peek(path) getOrElse BigInt(rnd.nextInt)
   
     def signConvert(bigInt: BigInt, width: Int): BigInt = {
-      if(bigInt.bitLength >= width) - ((BigInt(1) << width) - bigInt)
-      else bigInt
+      // Necessary b/c Verilator returns bigInts with whatever # of bits it feels like (?)
+      // Inconsistent with getWidth -- note also that since the bigInt is always unsigned,
+      // bitLength always gets the max # of bits required to represent bigInt
+      val w = bigInt.bitLength.max(width)
+      // Negative if MSB is set or in this case, ex: 3 bit wide: negative if >= 4
+      if (bigInt >= (BigInt(1) << (w - 1))) (bigInt - (BigInt(1) << w)) else bigInt
     }
 
     val result = signal match {
-      case s: SInt => signConvert(bigIntU, s.getWidth)
+      case s: SInt => 
+        signConvert(bigIntU, s.getWidth)
       case f: FixedPoint => signConvert(bigIntU, f.getWidth)
       case _ => bigIntU
     }


### PR DESCRIPTION
@chick basically, the symptom was: the BigInt out of Verilator wasn't always normalized to width.

I.e.  5 bit wide -8 would actually be output as 248. So if you did the normalization assuming 1 << 5 = 32, you'd get 216 instead of -8... Basically needed to adjust the perceived width as the max of the BigInt (unsigned) width or the Chisel width. 

Should be super quick review. Plz merge ASAP