### PR TITLE
Fix argument list for verilogToCpp().

### DIFF
--- a/src/main/scala/chisel3/iotesters/ChiselMain.scala
+++ b/src/main/scala/chisel3/iotesters/ChiselMain.scala
@@ -72,7 +72,7 @@ object chiselMain {
         // Copy API files
         copyVerilatorHeaderFiles(context.targetDir.toString)
         // Generate Verilator
-        assert(chisel3.Driver.verilogToCpp(dutName, dutName, dir, Seq(), new File(s"$dutName-harness.cpp")).! == 0)
+        assert(chisel3.Driver.verilogToCpp(dutName, dir, Seq(), new File(s"$dutName-harness.cpp")).! == 0)
         // Compile Verilator
         assert(chisel3.Driver.cppToExe(dutName, dir).! == 0)
       case "vcs" | "glsim" =>

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -327,10 +327,9 @@ private[iotesters] object setupVerilatorBackend {
         assert(
           chisel3.Driver.verilogToCpp(
             circuit.name,
-            circuit.name,
             dir,
             vSources = Seq(),
-            new File(cppHarnessFileName)
+            cppHarnessFile
           ).! == 0
         )
         assert(chisel3.Driver.cppToExe(circuit.name, dir).! == 0)


### PR DESCRIPTION
and use the already computed cppHarnessFile instead of only the name (and not the path) component.