### PR TITLE
fixed bug - verilator + vcs backends weren't propagating transforms correctly 

### DIFF
--- a/src/main/scala/chisel3/iotesters/VCSBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VCSBackend.scala
@@ -132,7 +132,6 @@ private[iotesters] object setupVCSBackend {
         val dut = getTopModule(circuit).asInstanceOf[T]
         val nodes = getChiselNodes(circuit)
         val annotations = firrtl.AnnotationMap(optionsManager.firrtlOptions.annotations ++ List(
-          firrtl.passes.memlib.InferReadWriteAnnotation(circuit.name),
           firrtl.annotations.Annotation(
             CircuitName(circuit.name),
             classOf[BlackBoxSourceHelper],
@@ -147,7 +146,7 @@ private[iotesters] object setupVCSBackend {
         verilogCompiler.compile(
           firrtl.CircuitState(chirrtl, firrtl.ChirrtlForm, Some(annotations)),
           verilogWriter,
-          List(new firrtl.passes.memlib.InferReadWrite)
+          optionsManager.firrtlOptions.customTransforms
         )
         verilogWriter.close()
 

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -229,7 +229,6 @@ private[iotesters] object setupVerilatorBackend {
         val nodes = getChiselNodes(circuit)
 
         val annotationMap = firrtl.AnnotationMap(optionsManager.firrtlOptions.annotations ++ List(
-          firrtl.passes.memlib.InferReadWriteAnnotation(circuit.name),
           firrtl.annotations.Annotation(
             CircuitName(circuit.name),
             classOf[BlackBoxSourceHelper],
@@ -244,7 +243,7 @@ private[iotesters] object setupVerilatorBackend {
         (new firrtl.VerilogCompiler).compile(
           CircuitState(chirrtl, ChirrtlForm, Some(annotationMap)),
           verilogWriter,
-          List(new firrtl.passes.memlib.InferReadWrite))
+          optionsManager.firrtlOptions.customTransforms)
         verilogWriter.close()
 
         val cppHarnessFileName = s"${circuit.name}-harness.cpp"


### PR DESCRIPTION
This might have been intentionally left out, but I think this was originally a bug. 

I wanted to test the generated Verilog (via my custom transform) against a testbench working with Verilator, but b/c the transform wasn't being run, I was always artificially getting the right result. The benefit of using Verilator + VCS is -- you should, assuming that you're providing all the right Verilog, etc. files, be able to test with the post-transform result. 

In general, I'm not sure why the decision was made to run Firrtl outside of chisel3.Driver.execute -- If it was simply to get the BlackBox resource directory in, I assume missing the transforms list was just a mistake. Though, if that's the case, there's got to be a less error-prone way to write this. 

I also removed the transform/annotation associated with InferReadWrite b/c a) that shouldn't always be automatically run and b) you should pass that in from the customTransforms/annotations firrtlOptions. I assume it was left in for legacy purposes...

The ExecutionOptionsManager, in general, needs *a lot* of cleanup, and how things are passed to the testers really needs to be carefully reviewed, since many of us have run across problems with options propagation. 

And in case anyone wants to know how transforms are collected from annotations (very mysterious to me -- also weird that it's in chisel3.Driver.execute...):

```
val transforms = circuit.annotations.map(_.transform).toSet.map { transformClass: Class[_ <: Transform] =>
      transformClass.newInstance()
    }
```

I guess you just need to hope that the annotation ordering matches the order of custom transforms you want to use. 