### PR TITLE
verilator: test that names are mangled so as to avoid  downstream con…

### DIFF
--- a/src/test/scala/verilator/doohickey.scala
+++ b/src/test/scala/verilator/doohickey.scala
@@ -6,6 +6,6 @@ class doohickey() extends Module {
   val io = new Bundle {
   }
   val bobs = Vec.fill(16) {
-    Module(new thingamabob()).io
+    Module(new iterator()).io
   }
 }

--- a/src/test/scala/verilator/iterator.scala
+++ b/src/test/scala/verilator/iterator.scala
@@ -4,7 +4,7 @@ package verilator
 // chisel3._ here!
 import Chisel._
 
-class thingamabob() extends Module {
+class iterator() extends Module {
   val io = new Bundle {
     val address = Vec(32, UInt(INPUT, 16)).asInput
     val thingy = UInt(INPUT, 4)


### PR DESCRIPTION
Updated test so that it causes a naming conflict with Verilator.

Chisel could mangle names to avoid naming conflicts downstream. Perhaps by always adding a chisel_ prefix to all symbols, so that "iterator" becomes "chisel_iterator"?

I think it would be annoying to have to enumerate ALL potential keyword conflicts.