### PR TITLE
Fix compiler errors due to firrtl emitter api changes

### DIFF
--- a/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
@@ -4,12 +4,12 @@ package chisel3.iotesters
 
 import java.io.File
 
-import chisel3.{Bundle, Data, Element, Module, Vec}
+import chisel3._
 import chisel3.internal.InstanceId
 import chisel3.internal.firrtl.Circuit
 
 import scala.sys.process._
-import scala.collection.mutable.{ArrayBuffer, HashMap}
+import scala.collection.mutable.ArrayBuffer
 
 // TODO: FIRRTL will eventually return valid names
 private[iotesters] object validName {
@@ -20,7 +20,7 @@ private[iotesters] object validName {
 private[iotesters] object getDataNames {
   def apply(name: String, data: Data): Seq[(Element, String)] = data match {
     case e: Element => Seq(e -> name)
-    case b: Bundle => b.elements.toSeq flatMap {case (n, e) => apply(s"${name}_$n", e)}
+    case b: Record => b.elements.toSeq flatMap {case (n, e) => apply(s"${name}_$n", e)}
     case v: Vec[_] => v.zipWithIndex flatMap {case (e, i) => apply(s"${name}_$i", e)}
   }
   def apply(dut: Module, separator: String = "."): Seq[(Element, String)] =
@@ -35,7 +35,7 @@ private[iotesters] object getPorts {
 private[iotesters] object flatten {
   def apply(data: Data): Seq[Element] = data match {
     case b: Element => Seq(b)
-    case b: Bundle => b.elements.toSeq flatMap (x => apply(x._2))
+    case b: Record => b.elements.toSeq flatMap (x => apply(x._2))
     case v: Vec[_] => v.toSeq flatMap apply
   }
 }

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -1,18 +1,16 @@
 // See LICENSE for license details.
 package chisel3.iotesters
 
-import chisel3.internal.InstanceId
-
-import scala.util.Random
-import java.io.{File, FileWriter, IOException, PrintStream, Writer}
-import java.nio.file.{FileAlreadyExistsException, Files, Paths}
+import java.io._
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import java.nio.file.{FileAlreadyExistsException, Files, Paths}
 
-import chisel3.{ChiselExecutionFailure, ChiselExecutionSuccess, SInt}
+import chisel3._
 import chisel3.experimental.FixedPoint
-import firrtl.annotations.{Annotation, CircuitName}
-import firrtl.transforms.{BlackBoxResource, BlackBoxInline, BlackBoxSource, BlackBoxSourceHelper, BlackBoxTargetDir}
-import firrtl.{AnnotationMap, FileUtils, FirrtlExecutionFailure, FirrtlExecutionSuccess}
+import chisel3.internal.InstanceId
+import firrtl._
+import firrtl.annotations.CircuitName
+import firrtl.transforms._
 
 /**
   * Copies the necessary header files used for verilator compilation to the specified destination folder
@@ -26,189 +24,171 @@ object copyVerilatorHeaderFiles {
       Files.createFile(simApiHFilePath)
       Files.createFile(verilatorApiHFilePath)
     } catch {
-      case x: FileAlreadyExistsException =>
+      case _: FileAlreadyExistsException =>
         System.out.format("")
-      case x: IOException => {
+      case x: IOException =>
         System.err.format("createFile error: %s%n", x)
-      }
     }
 
     Files.copy(getClass.getResourceAsStream("/sim_api.h"), simApiHFilePath, REPLACE_EXISTING)
     Files.copy(getClass.getResourceAsStream("/veri_api.h"), verilatorApiHFilePath, REPLACE_EXISTING)
   }
 }
-
 /**
   * Generates the Module specific verilator harness cpp file for verilator compilation
   */
-class GenVerilatorCppHarness(
-    dut: Chisel.Module,
-    nodes: Seq[InstanceId],
-    vcdFilePath: String) extends firrtl.Emitter {
-  import firrtl._
-  import firrtl.ir._
-  import firrtl.Mappers._
+object VerilatorCppHarnessGenerator {
+  def codeGen(dut: chisel3.Module, state: CircuitState, vcdFilePath: String): String = {
+    val codeBuffer = new StringBuilder
 
-  private def pushBack(writer: Writer, vector: String, pathName: String, width: BigInt) {
-    if (width <= 8) {
-      writer.write(s"        sim_data.$vector.push_back(new VerilatorCData(&(${pathName})));\n")
-    } else if (width <= 16) {
-      writer.write(s"        sim_data.$vector.push_back(new VerilatorSData(&(${pathName})));\n")
-    } else if (width <= 32) {
-      writer.write(s"        sim_data.$vector.push_back(new VerilatorIData(&(${pathName})));\n")
-    } else if (width <= 64) {
-      writer.write(s"        sim_data.$vector.push_back(new VerilatorQData(&(${pathName})));\n")
-    } else {
-      val numWords = (width-1)/32 + 1
-      writer.write(s"        sim_data.$vector.push_back(new VerilatorWData(${pathName}, ${numWords}));\n")
+    def pushBack(vector: String, pathName: String, width: BigInt) {
+      if (width <= 8) {
+        codeBuffer.append(s"        sim_data.$vector.push_back(new VerilatorCData(&($pathName)));\n")
+      } else if (width <= 16) {
+        codeBuffer.append(s"        sim_data.$vector.push_back(new VerilatorSData(&($pathName)));\n")
+      } else if (width <= 32) {
+        codeBuffer.append(s"        sim_data.$vector.push_back(new VerilatorIData(&($pathName)));\n")
+      } else if (width <= 64) {
+        codeBuffer.append(s"        sim_data.$vector.push_back(new VerilatorQData(&($pathName)));\n")
+      } else {
+        val numWords = (width-1)/32 + 1
+        codeBuffer.append(s"        sim_data.$vector.push_back(new VerilatorWData($pathName, $numWords));\n")
+      }
     }
-  }
 
-  def emit(state: CircuitState, writer: Writer): Unit = {
-    val circuit = state.circuit
     val (inputs, outputs) = getPorts(dut, "->")
     val dutName = dut.name
     val dutApiClassName = dutName + "_api_t"
     val dutVerilatorClassName = "V" + dutName
-    writer.write("#include \"%s.h\"\n".format(dutVerilatorClassName))
-    writer.write("#include \"verilated.h\"\n")
-    writer.write("#include \"veri_api.h\"\n")
-    writer.write("#if VM_TRACE\n")
-    writer.write("#include \"verilated_vcd_c.h\"\n")
-    writer.write("#endif\n")
-    writer.write("#include <iostream>\n")
-    writer.write(s"class ${dutApiClassName}: public sim_api_t<VerilatorDataWrapper*> {\n")
-    writer.write("public:\n")
-    writer.write(s"    ${dutApiClassName}(${dutVerilatorClassName}* _dut) {\n")
-    writer.write("        dut = _dut;\n")
-    writer.write("        main_time = 0L;\n")
-    writer.write("        is_exit = false;\n")
-    writer.write("#if VM_TRACE\n")
-    writer.write("        tfp = NULL;\n")
-    writer.write("#endif\n")
-    writer.write("    }\n")
-    writer.write("    void init_sim_data() {\n")
-    writer.write("        sim_data.inputs.clear();\n")
-    writer.write("        sim_data.outputs.clear();\n")
-    writer.write("        sim_data.signals.clear();\n")
+    codeBuffer.append("#include \"%s.h\"\n".format(dutVerilatorClassName))
+    codeBuffer.append("#include \"verilated.h\"\n")
+    codeBuffer.append("#include \"veri_api.h\"\n")
+    codeBuffer.append("#if VM_TRACE\n")
+    codeBuffer.append("#include \"verilated_vcd_c.h\"\n")
+    codeBuffer.append("#endif\n")
+    codeBuffer.append("#include <iostream>\n")
+    codeBuffer.append(s"class $dutApiClassName: public sim_api_t<VerilatorDataWrapper*> {\n")
+    codeBuffer.append("public:\n")
+    codeBuffer.append(s"    $dutApiClassName($dutVerilatorClassName* _dut) {\n")
+    codeBuffer.append("        dut = _dut;\n")
+    codeBuffer.append("        main_time = 0L;\n")
+    codeBuffer.append("        is_exit = false;\n")
+    codeBuffer.append("#if VM_TRACE\n")
+    codeBuffer.append("        tfp = NULL;\n")
+    codeBuffer.append("#endif\n")
+    codeBuffer.append("    }\n")
+    codeBuffer.append("    void init_sim_data() {\n")
+    codeBuffer.append("        sim_data.inputs.clear();\n")
+    codeBuffer.append("        sim_data.outputs.clear();\n")
+    codeBuffer.append("        sim_data.signals.clear();\n")
     inputs.toList foreach { case (node, name) =>
-      pushBack(writer, "inputs", name replace (dutName, "dut"), node.getWidth)
+      pushBack("inputs", name replace (dutName, "dut"), node.getWidth)
     }
     outputs.toList foreach { case (node, name) =>
-      pushBack(writer, "outputs", name replace (dutName, "dut"), node.getWidth)
+      pushBack("outputs", name replace (dutName, "dut"), node.getWidth)
     }
-    pushBack(writer, "signals", "dut->reset", 1)
-    writer.write(s"""        sim_data.signal_map["%s"] = 0;\n""".format(dut.reset.pathName))
-    writer.write("    }\n")
-    writer.write("#if VM_TRACE\n")
-    writer.write("     void init_dump(VerilatedVcdC* _tfp) { tfp = _tfp; }\n")
-    writer.write("#endif\n")
-    writer.write("    inline bool exit() { return is_exit; }\n")
+    pushBack("signals", "dut->reset", 1)
+    codeBuffer.append(s"""        sim_data.signal_map["%s"] = 0;\n""".format(dut.reset.pathName))
+    codeBuffer.append("    }\n")
+    codeBuffer.append("#if VM_TRACE\n")
+    codeBuffer.append("     void init_dump(VerilatedVcdC* _tfp) { tfp = _tfp; }\n")
+    codeBuffer.append("#endif\n")
+    codeBuffer.append("    inline bool exit() { return is_exit; }\n")
 
     // required for sc_time_stamp()
-    writer.write("    virtual inline double get_time_stamp() {\n")
-    writer.write("        return main_time;\n")
-    writer.write("    }\n")
+    codeBuffer.append("    virtual inline double get_time_stamp() {\n")
+    codeBuffer.append("        return main_time;\n")
+    codeBuffer.append("    }\n")
 
-    writer.write("private:\n")
-    writer.write(s"    ${dutVerilatorClassName}* dut;\n")
-    writer.write("    bool is_exit;\n")
-    writer.write("    vluint64_t main_time;\n")
-    writer.write("#if VM_TRACE\n")
-    writer.write("    VerilatedVcdC* tfp;\n")
-    writer.write("#endif\n")
-    writer.write("    virtual inline size_t put_value(VerilatorDataWrapper* &sig, uint64_t* data, bool force=false) {\n")
-    writer.write("        return sig->put_value(data);\n")
-    writer.write("    }\n")
-    writer.write("    virtual inline size_t get_value(VerilatorDataWrapper* &sig, uint64_t* data) {\n")
-    writer.write("        return sig->get_value(data);\n")
-    writer.write("    }\n")
-    writer.write("    virtual inline size_t get_chunk(VerilatorDataWrapper* &sig) {\n")
-    writer.write("        return sig->get_num_words();\n")
-    writer.write("    } \n")
-    writer.write("    virtual inline void reset() {\n")
-    writer.write("        dut->reset = 1;\n")
-    writer.write("        step();\n")
-    writer.write("    }\n")
-    writer.write("    virtual inline void start() {\n")
-    writer.write("        dut->reset = 0;\n")
-    writer.write("    }\n")
-    writer.write("    virtual inline void finish() {\n")
-    writer.write("        dut->eval();\n")
-    writer.write("        is_exit = true;\n")
-    writer.write("    }\n")
-    writer.write("    virtual inline void step() {\n")
-    writer.write("        dut->clock = 0;\n")
-    writer.write("        dut->eval();\n")
-    writer.write("#if VM_TRACE\n")
-    writer.write("        if (tfp) tfp->dump(main_time);\n")
-    writer.write("#endif\n")
-    writer.write("        main_time++;\n")
-    writer.write("        dut->clock = 1;\n")
-    writer.write("        dut->eval();\n")
-    writer.write("#if VM_TRACE\n")
-    writer.write("        if (tfp) tfp->dump(main_time);\n")
-    writer.write("#endif\n")
-    writer.write("        main_time++;\n")
-    writer.write("    }\n")
-    writer.write("    virtual inline void update() {\n")
-    writer.write("        dut->_eval_settle(dut->__VlSymsp);\n")
-    writer.write("    }\n")
-    writer.write("};\n")
+    codeBuffer.append("private:\n")
+    codeBuffer.append(s"    $dutVerilatorClassName* dut;\n")
+    codeBuffer.append("    bool is_exit;\n")
+    codeBuffer.append("    vluint64_t main_time;\n")
+    codeBuffer.append("#if VM_TRACE\n")
+    codeBuffer.append("    VerilatedVcdC* tfp;\n")
+    codeBuffer.append("#endif\n")
+    codeBuffer.append("    virtual inline size_t put_value(VerilatorDataWrapper* &sig, uint64_t* data, bool force=false) {\n")
+    codeBuffer.append("        return sig->put_value(data);\n")
+    codeBuffer.append("    }\n")
+    codeBuffer.append("    virtual inline size_t get_value(VerilatorDataWrapper* &sig, uint64_t* data) {\n")
+    codeBuffer.append("        return sig->get_value(data);\n")
+    codeBuffer.append("    }\n")
+    codeBuffer.append("    virtual inline size_t get_chunk(VerilatorDataWrapper* &sig) {\n")
+    codeBuffer.append("        return sig->get_num_words();\n")
+    codeBuffer.append("    } \n")
+    codeBuffer.append("    virtual inline void reset() {\n")
+    codeBuffer.append("        dut->reset = 1;\n")
+    codeBuffer.append("        step();\n")
+    codeBuffer.append("    }\n")
+    codeBuffer.append("    virtual inline void start() {\n")
+    codeBuffer.append("        dut->reset = 0;\n")
+    codeBuffer.append("    }\n")
+    codeBuffer.append("    virtual inline void finish() {\n")
+    codeBuffer.append("        dut->eval();\n")
+    codeBuffer.append("        is_exit = true;\n")
+    codeBuffer.append("    }\n")
+    codeBuffer.append("    virtual inline void step() {\n")
+    codeBuffer.append("        dut->clock = 0;\n")
+    codeBuffer.append("        dut->eval();\n")
+    codeBuffer.append("#if VM_TRACE\n")
+    codeBuffer.append("        if (tfp) tfp->dump(main_time);\n")
+    codeBuffer.append("#endif\n")
+    codeBuffer.append("        main_time++;\n")
+    codeBuffer.append("        dut->clock = 1;\n")
+    codeBuffer.append("        dut->eval();\n")
+    codeBuffer.append("#if VM_TRACE\n")
+    codeBuffer.append("        if (tfp) tfp->dump(main_time);\n")
+    codeBuffer.append("#endif\n")
+    codeBuffer.append("        main_time++;\n")
+    codeBuffer.append("    }\n")
+    codeBuffer.append("    virtual inline void update() {\n")
+    codeBuffer.append("        dut->_eval_settle(dut->__VlSymsp);\n")
+    codeBuffer.append("    }\n")
+    codeBuffer.append("};\n")
 
     // The following isn't strictly required unless we emit (possibly indirectly) something
     // requiring a time-stamp (such as an assert).
-    writer.write(s"static ${dutApiClassName} * _Top_api;\n")
-    writer.write("double sc_time_stamp () { return _Top_api->get_time_stamp(); }\n")
+    codeBuffer.append(s"static $dutApiClassName * _Top_api;\n")
+    codeBuffer.append("double sc_time_stamp () { return _Top_api->get_time_stamp(); }\n")
 
-    writer.write("int main(int argc, char **argv, char **env) {\n")
-    writer.write("    Verilated::commandArgs(argc, argv);\n")
-    writer.write(s"    ${dutVerilatorClassName}* top = new ${dutVerilatorClassName};\n")
-    writer.write("    std::string vcdfile = \"%s\";\n".format(vcdFilePath))
-    writer.write("    std::vector<std::string> args(argv+1, argv+argc);\n")
-    writer.write("    std::vector<std::string>::const_iterator it;\n")
-    writer.write("    for (it = args.begin() ; it != args.end() ; it++) {\n")
-    writer.write("      if (it->find(\"+waveform=\") == 0) vcdfile = it->c_str()+10;\n")
-    writer.write("    }\n")
-    writer.write("#if VM_TRACE\n")
-    writer.write("    Verilated::traceEverOn(true);\n")
-    writer.write("    VL_PRINTF(\"Enabling waves..\");\n")
-    writer.write("    VerilatedVcdC* tfp = new VerilatedVcdC;\n")
-    writer.write("    top->trace(tfp, 99);\n")
-    writer.write("    tfp->open(vcdfile.c_str());\n")
-    writer.write("#endif\n")
-    writer.write(s"    ${dutApiClassName} api(top);\n")
-    writer.write("    _Top_api = &api; /* required for sc_time_stamp() */\n")
-    writer.write("    api.init_sim_data();\n")
-    writer.write("    api.init_channels();\n")
-    writer.write("#if VM_TRACE\n")
-    writer.write("    api.init_dump(tfp);\n")
-    writer.write("#endif\n")
-    writer.write("    while(!api.exit()) api.tick();\n")
-    writer.write("#if VM_TRACE\n")
-    writer.write("    if (tfp) tfp->close();\n")
-    writer.write("    delete tfp;\n")
-    writer.write("#endif\n")
-    writer.write("    delete top;\n")
-    writer.write("    exit(0);\n")
-    writer.write("}\n")
-    writer.close()
+    codeBuffer.append("int main(int argc, char **argv, char **env) {\n")
+    codeBuffer.append("    Verilated::commandArgs(argc, argv);\n")
+    codeBuffer.append(s"    $dutVerilatorClassName* top = new $dutVerilatorClassName;\n")
+    codeBuffer.append("    std::string vcdfile = \"%s\";\n".format(vcdFilePath))
+    codeBuffer.append("    std::vector<std::string> args(argv+1, argv+argc);\n")
+    codeBuffer.append("    std::vector<std::string>::const_iterator it;\n")
+    codeBuffer.append("    for (it = args.begin() ; it != args.end() ; it++) {\n")
+    codeBuffer.append("      if (it->find(\"+waveform=\") == 0) vcdfile = it->c_str()+10;\n")
+    codeBuffer.append("    }\n")
+    codeBuffer.append("#if VM_TRACE\n")
+    codeBuffer.append("    Verilated::traceEverOn(true);\n")
+    codeBuffer.append("    VL_PRINTF(\"Enabling waves..\");\n")
+    codeBuffer.append("    VerilatedVcdC* tfp = new VerilatedVcdC;\n")
+    codeBuffer.append("    top->trace(tfp, 99);\n")
+    codeBuffer.append("    tfp->open(vcdfile.c_str());\n")
+    codeBuffer.append("#endif\n")
+    codeBuffer.append(s"    $dutApiClassName api(top);\n")
+    codeBuffer.append("    _Top_api = &api; /* required for sc_time_stamp() */\n")
+    codeBuffer.append("    api.init_sim_data();\n")
+    codeBuffer.append("    api.init_channels();\n")
+    codeBuffer.append("#if VM_TRACE\n")
+    codeBuffer.append("    api.init_dump(tfp);\n")
+    codeBuffer.append("#endif\n")
+    codeBuffer.append("    while(!api.exit()) api.tick();\n")
+    codeBuffer.append("#if VM_TRACE\n")
+    codeBuffer.append("    if (tfp) tfp->close();\n")
+    codeBuffer.append("    delete tfp;\n")
+    codeBuffer.append("#endif\n")
+    codeBuffer.append("    delete top;\n")
+    codeBuffer.append("    exit(0);\n")
+    codeBuffer.append("}\n")
+    codeBuffer.toString()
   }
-}
-
-class VerilatorCppHarnessCompiler(dut: Chisel.Module,
-    nodes: Seq[InstanceId], vcdFilePath: String) extends firrtl.Compiler {
-  def emitter = new GenVerilatorCppHarness(dut, nodes, vcdFilePath)
-  def transforms = Seq(
-    new firrtl.ChirrtlToHighFirrtl,
-    new firrtl.IRToWorkingIR,
-    new firrtl.ResolveAndCheck
-  )
 }
 
 private[iotesters] object setupVerilatorBackend {
   def apply[T <: chisel3.Module](dutGen: () => T, optionsManager: TesterOptionsManager): (T, Backend) = {
-    import firrtl.{CircuitState, ChirrtlForm}
+    import firrtl.{ChirrtlForm, CircuitState}
 
     optionsManager.makeTargetDir()
 
@@ -221,12 +201,8 @@ private[iotesters] object setupVerilatorBackend {
     chisel3.Driver.execute(optionsManager, dutGen) match {
       case ChiselExecutionSuccess(Some(circuit), emitted, _) =>
 
-        //      val circuit = chisel3.Driver.elaborate(dutGen)
-        //      val chirrtl = firrtl.Parser.parse(chisel3.Driver.emit(circuit))
-
         val chirrtl = firrtl.Parser.parse(emitted)
         val dut = getTopModule(circuit).asInstanceOf[T]
-        val nodes = getChiselNodes(circuit)
 
         val annotationMap = firrtl.AnnotationMap(optionsManager.firrtlOptions.annotations ++ List(
           firrtl.annotations.Annotation(
@@ -236,25 +212,27 @@ private[iotesters] object setupVerilatorBackend {
           )
         ))
 
+        copyVerilatorHeaderFiles(optionsManager.targetDirName)
+
         // Generate Verilog
         val verilogFile = new File(dir, s"${circuit.name}.v")
         val verilogWriter = new FileWriter(verilogFile)
 
-        (new firrtl.VerilogCompiler).compile(
-          CircuitState(chirrtl, ChirrtlForm, Some(annotationMap)),
-          verilogWriter,
-          optionsManager.firrtlOptions.customTransforms)
+        val compileResult = (new firrtl.VerilogCompiler).compileAndEmit(
+          CircuitState(chirrtl, ChirrtlForm, Some(annotationMap))
+        )
+        val compiledStuff = compileResult.getEmittedCircuit
+        verilogWriter.write(compiledStuff.value)
         verilogWriter.close()
 
         val cppHarnessFileName = s"${circuit.name}-harness.cpp"
         val cppHarnessFile = new File(dir, cppHarnessFileName)
         val cppHarnessWriter = new FileWriter(cppHarnessFile)
         val vcdFile = new File(dir, s"${circuit.name}.vcd")
-        val harnessCompiler = new VerilatorCppHarnessCompiler(dut, nodes, vcdFile.toString)
-        copyVerilatorHeaderFiles(dir.toString)
-        harnessCompiler.compile(
-          CircuitState(chirrtl, ChirrtlForm, Some(annotationMap)), // TODO do we actually need this annotation?
-          cppHarnessWriter)
+        val emittedStuff = VerilatorCppHarnessGenerator.codeGen(
+          dut, CircuitState(chirrtl, ChirrtlForm, Some(annotationMap)), vcdFile.toString
+        )
+        cppHarnessWriter.append(emittedStuff)
         cppHarnessWriter.close()
 
         assert(
@@ -269,8 +247,9 @@ private[iotesters] object setupVerilatorBackend {
 
         val command = if(optionsManager.testerOptions.testCmd.nonEmpty) {
           optionsManager.testerOptions.testCmd
-        } else {
-          Seq((new File(dir, s"V${circuit.name}")).toString)
+        }
+        else {
+          Seq(new File(dir, s"V${circuit.name}").toString)
         }
 
         (dut, new VerilatorBackend(dut, command))
@@ -310,7 +289,7 @@ private[iotesters] class VerilatorBackend(dut: Chisel.Module,
       // bitLength always gets the max # of bits required to represent bigInt
       val w = bigInt.bitLength.max(width)
       // Negative if MSB is set or in this case, ex: 3 bit wide: negative if >= 4
-      if (bigInt >= (BigInt(1) << (w - 1))) (bigInt - (BigInt(1) << w)) else bigInt
+      if(bigInt >= (BigInt(1) << (w - 1))) bigInt - (BigInt(1) << w) else bigInt
     }
 
     val result = signal match {
@@ -319,7 +298,7 @@ private[iotesters] class VerilatorBackend(dut: Chisel.Module,
       case f: FixedPoint => signConvert(bigIntU, f.getWidth)
       case _ => bigIntU
     }
-    if (verbose) logger println s"  PEEK ${path} -> ${bigIntToStr(result, base)}"
+    if (verbose) logger println s"  PEEK $path -> ${bigIntToStr(result, base)}"
     result
   }
 
@@ -330,7 +309,7 @@ private[iotesters] class VerilatorBackend(dut: Chisel.Module,
     val got = peek(signal, None)
     val good = got == expected
     if (verbose) logger println (
-      s"""${msg}  EXPECT ${path} -> ${bigIntToStr(got, base)} == """ +
+      s"""$msg  EXPECT $path -> ${bigIntToStr(got, base)} == """ +
         s"""${bigIntToStr(expected, base)} ${if (good) "PASS" else "FAIL"}""")
     good
   }
@@ -342,7 +321,7 @@ private[iotesters] class VerilatorBackend(dut: Chisel.Module,
 
   def poke(path: String, value: BigInt)
           (implicit logger: PrintStream, verbose: Boolean, base: Int) {
-    if (verbose) logger println s"  POKE ${path} <- ${bigIntToStr(value, base)}"
+    if (verbose) logger println s"  POKE $path <- ${bigIntToStr(value, base)}"
     simApiInterface.poke(path, value)
   }
 
@@ -354,7 +333,7 @@ private[iotesters] class VerilatorBackend(dut: Chisel.Module,
   def peek(path: String)
           (implicit logger: PrintStream, verbose: Boolean, base: Int): BigInt = {
     val result = simApiInterface.peek(path) getOrElse BigInt(rnd.nextInt)
-    if (verbose) logger println s"  PEEK ${path} -> ${bigIntToStr(result, base)}"
+    if (verbose) logger println s"  PEEK $path -> ${bigIntToStr(result, base)}"
     result
   }
 
@@ -363,7 +342,7 @@ private[iotesters] class VerilatorBackend(dut: Chisel.Module,
     val got = simApiInterface.peek(path) getOrElse BigInt(rnd.nextInt)
     val good = got == expected
     if (verbose) logger println (
-      s"""${msg}  EXPECT ${path} got ${bigIntToStr(got, base)} expected""" +
+      s"""$msg  EXPECT $path got ${bigIntToStr(got, base)} expected""" +
         s"""${bigIntToStr(expected, base)} ${if (good) "PASS" else "FAIL"}""")
     good
   }

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -259,7 +259,7 @@ private[iotesters] object setupVerilatorBackend {
   }
 }
 
-private[iotesters] class VerilatorBackend(dut: Chisel.Module, 
+private[iotesters] class VerilatorBackend(dut: Module,
                                           cmd: Seq[String],
                                           _seed: Long = System.currentTimeMillis) extends Backend(_seed) {
 

--- a/src/test/scala/chisel3/iotesters/VecFillSpec.scala
+++ b/src/test/scala/chisel3/iotesters/VecFillSpec.scala
@@ -1,0 +1,40 @@
+// See LICENSE for license details.
+
+package chisel3.iotesters
+
+import org.scalatest.{FreeSpec, Matchers}
+
+import chisel3._
+
+class VF extends Module {
+  val io = IO(new Bundle {
+    val addr = Input(UInt(8.W))
+    val value = Output(UInt(8.W))
+  })
+
+  val vec = Wire(Vec(11, UInt(8.W)))
+  vec := Vec(Seq.tabulate(11)(n => n.U))
+
+  io.value := vec(io.addr)
+}
+
+class VFTester(c: VF) extends PeekPokeTester(c) {
+  for(i <- 0 until 11) {
+    poke(c.io.addr, i)
+    expect(c.io.value, i)
+    step(1)
+  }
+  for(i <- 11 until 111) {
+    poke(c.io.addr, i)
+    expect(c.io.value, i % 11)
+    step(1)
+  }
+}
+
+class VecFillSpec extends FreeSpec with Matchers {
+  "should initialize vector" in {
+    iotesters.Driver.execute(Array("-tiv"), () => new VF) { c =>
+      new VFTester(c)
+    } should be(true)
+  }
+}

--- a/src/test/scala/verilator/doohickey.scala
+++ b/src/test/scala/verilator/doohickey.scala
@@ -2,10 +2,13 @@ package verilator
 
 import chisel3._
 
+/**
+  * The practice of creating Seq's or Vec's of IO's is problematic
+  */
 class doohickey() extends Module {
-  val io = new Bundle {
-  }
-  val bobs = Vec.fill(16) {
+  val io = IO(new Bundle {})
+  //TODO: figure out if this idiom is the key point here or if some other example would suffice
+  val bobs = Seq.fill(16) {
     Module(new thingamabob()).io
   }
 }


### PR DESCRIPTION
Recent changes to emitter stuff in firrtl, broke the rather brittle verilator backend.  I have cleaned this up a fair amount, although there is probably still some room for improvement.
Reworked the VerilatorCppHarnessCompiler stuff.
It seemed to be unnecessarily using Transforms to do a simple template substitution.
chiselMain had it's own hooks into the above.  Cleaned this up as much as I dared
Fix deprecated code
Reg(init -> RegInit(
log2Up -> Log2Ceil
Fixed up style (I needed this to debug this mess)