### PR TITLE
Sim api

### DIFF
--- a/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
@@ -4,7 +4,7 @@ package chisel3.iotesters
 
 import java.io.File
 
-import chisel3.{Bundle, Data, Element, Module, Vec}
+import chisel3._
 import chisel3.internal.InstanceId
 import chisel3.internal.firrtl.Circuit
 
@@ -20,7 +20,7 @@ private[iotesters] object validName {
 private[iotesters] object getDataNames {
   def apply(name: String, data: Data): Seq[(Element, String)] = data match {
     case e: Element => Seq(e -> name)
-    case b: Bundle => b.elements.toSeq flatMap {case (n, e) => apply(s"${name}_$n", e)}
+    case b: Record => b.elements.toSeq flatMap {case (n, e) => apply(s"${name}_$n", e)}
     case v: Vec[_] => v.zipWithIndex flatMap {case (e, i) => apply(s"${name}_$i", e)}
   }
   def apply(dut: Module, separator: String = "."): Seq[(Element, String)] =
@@ -35,7 +35,7 @@ private[iotesters] object getPorts {
 private[iotesters] object flatten {
   def apply(data: Data): Seq[Element] = data match {
     case b: Element => Seq(b)
-    case b: Bundle => b.elements.toSeq flatMap (x => apply(x._2))
+    case b: Record => b.elements.toSeq flatMap (x => apply(x._2))
     case v: Vec[_] => v.toSeq flatMap apply
   }
 }

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -8,7 +8,7 @@ import java.io.{File, FileWriter, IOException, PrintStream, Writer}
 import java.nio.file.{FileAlreadyExistsException, Files, Paths}
 import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 
-import chisel3.{ChiselExecutionFailure, ChiselExecutionSuccess, SInt}
+import chisel3.{ChiselExecutionFailure, ChiselExecutionSuccess, SInt, Module}
 import chisel3.experimental.FixedPoint
 import firrtl.annotations.{Annotation, CircuitName}
 import firrtl.transforms.{BlackBoxResource, BlackBoxInline, BlackBoxSource, BlackBoxSourceHelper, BlackBoxTargetDir}
@@ -42,7 +42,7 @@ object copyVerilatorHeaderFiles {
   * Generates the Module specific verilator harness cpp file for verilator compilation
   */
 class GenVerilatorCppHarness(
-    dut: Chisel.Module,
+    dut: Module,
     nodes: Seq[InstanceId],
     vcdFilePath: String) extends firrtl.Emitter {
   import firrtl._
@@ -196,7 +196,7 @@ class GenVerilatorCppHarness(
   }
 }
 
-class VerilatorCppHarnessCompiler(dut: Chisel.Module,
+class VerilatorCppHarnessCompiler(dut: Module,
     nodes: Seq[InstanceId], vcdFilePath: String) extends firrtl.Compiler {
   def emitter = new GenVerilatorCppHarness(dut, nodes, vcdFilePath)
   def transforms = Seq(
@@ -280,7 +280,7 @@ private[iotesters] object setupVerilatorBackend {
   }
 }
 
-private[iotesters] class VerilatorBackend(dut: Chisel.Module, 
+private[iotesters] class VerilatorBackend(dut: Module, 
                                           cmd: Seq[String],
                                           _seed: Long = System.currentTimeMillis) extends Backend(_seed) {
 


### PR DESCRIPTION
@chick Not sure why VerilatorBackend was using Chisel.Module (although it prob doesn't matter?) -- I'm trying to debug why, in an sbt project with both chisel2 and chisel3 (so I can incrementally port and test stuff), I'm having issues running Verilator. It seems like it's getting sim_api.h from the wrong resource directory, but in the meantime, I'm not sure why it was Chisel.Module... 