### PR TITLE
Fix verilator custom transforms not being run

### DIFF
--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -212,6 +212,10 @@ private[iotesters] object setupVerilatorBackend {
           )
         ))
 
+        val transforms = circuit.annotations.map(_.transform).toSet.map { transformClass: Class[_ <: Transform] =>
+          transformClass.newInstance()
+        }.toSeq
+
         copyVerilatorHeaderFiles(optionsManager.targetDirName)
 
         // Generate Verilog
@@ -219,7 +223,8 @@ private[iotesters] object setupVerilatorBackend {
         val verilogWriter = new FileWriter(verilogFile)
 
         val compileResult = (new firrtl.VerilogCompiler).compileAndEmit(
-          CircuitState(chirrtl, ChirrtlForm, Some(annotationMap))
+          CircuitState(chirrtl, ChirrtlForm, Some(annotationMap)),
+          customTransforms = transforms
         )
         val compiledStuff = compileResult.getEmittedCircuit
         verilogWriter.write(compiledStuff.value)

--- a/src/test/scala/chisel3/iotesters/VecFillSpec.scala
+++ b/src/test/scala/chisel3/iotesters/VecFillSpec.scala
@@ -24,11 +24,7 @@ class VFTester(c: VF) extends PeekPokeTester(c) {
     expect(c.io.value, i)
     step(1)
   }
-  for(i <- 11 until 111) {
-    poke(c.io.addr, i)
-    expect(c.io.value, i % 11)
-    step(1)
-  }
+  // behavior of indexing past end of vec is undefined
 }
 
 class VecFillSpec extends FreeSpec with Matchers {


### PR DESCRIPTION
Custom transforms specified by annotations were not being run by Driver.execute when using the verilator backend