### PR TITLE
verilator DUT cpp generation bug

### DIFF
--- a/src/test/scala/verilator/Verilator.scala
+++ b/src/test/scala/verilator/Verilator.scala
@@ -14,6 +14,7 @@ class VerilatorTest extends FlatSpec with Matchers {
           "--compile",
           "--genHarness",
           "--minimumCompatibility", "3.0.0")
-      chiselMain(args, () => new doohickey())
+      chiselMain(args, () => new doohickey(4))
+      chiselMain(args, () => new doohickey(8))
     }
 }

--- a/src/test/scala/verilator/doohickey.scala
+++ b/src/test/scala/verilator/doohickey.scala
@@ -5,8 +5,10 @@ import chisel3._
 /**
   * The practice of creating Seq's or Vec's of IO's is problematic
   */
-class doohickey() extends Module {
-  val io = IO(new Bundle {})
+class doohickey(veclength: Int) extends Module {
+  val io = IO(new Bundle {
+    val dummy = Input(Vec(veclength, UInt(4.W)))
+  })
   //TODO: figure out if this idiom is the key point here or if some other example would suffice
   val bobs = Seq.fill(16) {
     Module(new thingamabob()).io


### PR DESCRIPTION
Running a Verilator test twice doesn't reproduce the DUT cpp code. This can be seen by first generating a DUT with a Vec IO of some size, and then generating a DUT with the Vec IO size increased.

I don't have a solution, but I wrote a test that fails.