### PR TITLE
Add IntermediateBackend for generating verilog testbenches

### DIFF
--- a/src/main/scala/chisel3/iotesters/IntermediateBackend.scala
+++ b/src/main/scala/chisel3/iotesters/IntermediateBackend.scala
@@ -1,0 +1,108 @@
+// See LICENSE for license details.
+package chisel3.iotesters
+
+import java.io.PrintStream
+
+import chisel3._
+import chisel3.internal.InstanceId
+
+sealed trait Statement {
+  def serialize: String
+}
+
+case class PokeStatement(signal: String, value: BigInt) extends Statement {
+  def serialize = s"poke $signal : $value"
+}
+case class ExpectStatement(signal: String, value: BigInt, msg: String) extends Statement {
+  val msgReplaced = msg.replace("\n", ":")
+  def serialize = s"expect $signal : $value : $msgReplaced"
+}
+case class StepStatement(n: Int) extends Statement {
+  def serialize = s"step $n"
+}
+case class ResetStatement(n: Int) extends Statement {
+  def serialize = s"reset $n"
+}
+
+class IntermediateBackend(
+    dut: Module,
+    optionsManager: TesterOptionsManager = new TesterOptionsManager)
+  extends Backend(_seed = System.currentTimeMillis())
+{
+
+  val portNames = getDataNames("io", dut.io).toMap
+
+  val statements = scala.collection.mutable.Queue[Statement]()
+
+  def poke(signal: InstanceId, value: BigInt, off: Option[Int])
+          (implicit logger: PrintStream, verbose: Boolean, base: Int): Unit = {
+    signal match {
+      case port: Bits =>
+        val name = portNames(port)
+        poke(name, value)
+      case _ =>
+    }
+          }
+
+  def peek(signal: InstanceId, off: Option[Int])
+          (implicit logger: PrintStream, verbose: Boolean, base: Int): BigInt = {
+    throw new Exception("Peek not supported!")
+  }
+
+  def poke(path: String, value: BigInt)
+          (implicit logger: PrintStream, verbose: Boolean, base: Int): Unit = {
+    statements += PokeStatement(path, value)
+  }
+
+  def peek(path: String)
+          (implicit logger: PrintStream, verbose: Boolean, base: Int): BigInt = {
+    throw new Exception("Peek not supported!")
+  }
+
+  def expect(signal: InstanceId, expected: BigInt, msg: => String)
+            (implicit logger: PrintStream, verbose: Boolean, base: Int): Boolean = {
+    signal match {
+      case port: Bits =>
+        val name = portNames(port)
+        expect(name, expected, msg)
+      case _ =>
+        false
+    }
+  }
+
+  def expect(path: String, expected: BigInt, msg: => String)
+            (implicit logger: PrintStream, verbose: Boolean, base: Int): Boolean = {
+    statements += ExpectStatement(path, expected, msg)
+    true
+  }
+
+  def step(n: Int)(implicit logger: PrintStream): Unit = {
+    statements += StepStatement(n)
+  }
+
+  def reset(n: Int): Unit = {
+    statements += ResetStatement(n)
+  }
+
+  def finish(implicit logger: PrintStream): Unit = {
+    optionsManager.testerOptions.intermediateReportFunc(statements)
+  }
+
+}
+
+private[iotesters] object setupIntermediateBackend
+{
+  def apply[T <: chisel3.Module](
+      dutGen: () => T,
+      optionsManager: TesterOptionsManager = new TesterOptionsManager): (T, Backend) =
+  {
+    chisel3.Driver.execute(optionsManager, dutGen) match {
+      case ChiselExecutionSuccess(Some(circuit), firrtlText, Some(firrtlExecutionResult)) =>
+        val dut = getTopModule(circuit).asInstanceOf[T]
+        (dut, new IntermediateBackend(dut, optionsManager = optionsManager))
+      case _ =>
+        throw new Exception("Problem with compilation")
+    }
+  }
+}
+

--- a/src/main/scala/chisel3/iotesters/TesterOptions.scala
+++ b/src/main/scala/chisel3/iotesters/TesterOptions.scala
@@ -3,6 +3,7 @@
 package chisel3.iotesters
 
 import java.io.File
+import scala.collection.mutable.Queue
 
 import chisel3.HasChiselExecutionOptions
 import firrtl.{HasFirrtlOptions, ComposableOptions, ExecutionOptionsManager}
@@ -22,7 +23,9 @@ case class TesterOptions(
                           testCmd:         Seq[String] = Seq.empty,
                           backendName:     String  = "firrtl",
                           logFileName:     String  = "",
-                          waveform:        Option[File] = None) extends ComposableOptions
+                          waveform:        Option[File] = None,
+                          intermediateReportFunc: Queue[Statement] => Unit = _.foreach { s => println(s.serialize) }
+                            ) extends ComposableOptions
 
 trait HasTesterOptions {
   self: ExecutionOptionsManager =>
@@ -34,7 +37,7 @@ trait HasTesterOptions {
   parser.opt[String]("backend-name").valueName("<firrtl|verilator|vcs>")
     .abbr("tbn")
     .validate { x =>
-      if (Array("firrtl", "verilator", "vcs").contains(x.toLowerCase)) parser.success
+      if (Array("firrtl", "verilator", "vcs", "intermediate").contains(x.toLowerCase)) parser.success
       else parser.failure(s"$x not a legal backend name")
     }
     .foreach { x => testerOptions = testerOptions.copy(backendName = x) }


### PR DESCRIPTION
This is a rough stab at getting the basic functionality to generate a (in my case verilog) testbench via the chisel testers API.

The thing I wanted to do was to run the jtag chisel tests I had written on the top level craft2-chip, which is not easy to do with the chisel testers API for many reasons (makefile-based build system doing some magic with external IP, wanting to use ncsim, and more). What I wanted was something like @shunshou's nice [tester mixin that dumps a verilog version of the test you just ran](https://github.com/ucb-bar/dsptools/blob/master/src/main/scala/dsptools/tester/VerilogTbDump.scala), but it wasn't convenient to use because of the tests I was using from @ducky64 using a different testing API.

I ended up adding a backend that generates an intermediate representation of the test you just ran and then (in a separate repo) an application specific "compiler" (really just a handlebars template based on Angie's VerilogTbDump) for the IR to a verilog testbench appropriate for my application. The IR is really simple- poke, expect, step, and reset. I want to plant my flag on the names birrtl or tirrtl (behavioral or testing intermediate representation...) on the off chance that this becomes a thing

Do you guys think this idea has merit? It sure was handy for me. I was thinking of adding new backends that extend Verilator with Intermediate or VCS with Intermediate that runs the test and then adds the event to the queue (also, peeks would not throw an exception and would add expects to the event queue). I'm not necessarily a fan of the way I've written the code- maybe it would be better to have an option that every backend respects rather than new backends that work the same but add this new functionality. In that case I'd like to have a DoNothing backend for situations where for whatever reason it is hard to get a chisel testers backend running your circuit.

Sorry for writing a book!