### PR TITLE
Remove references to obsolete Mem fields.

### DIFF
--- a/src/test/scala/examples/Router.scala
+++ b/src/test/scala/examples/Router.scala
@@ -54,9 +54,6 @@ class Router extends Module {
   val tbl   = Mem(depth, UInt(BigInt(n).bitLength.W))
 
   when(reset) {
-    tbl.indices.foreach { index =>
-      tbl(index) := 0.asUInt(Router.addressWidth.W)
-    }
     io.read_routing_table_request.nodeq()
     io.load_routing_table_request.nodeq()
     io.read_routing_table_response.noenq()


### PR DESCRIPTION
When the VecLike trait was removed from Mems, the indicies field disappeared.